### PR TITLE
refactor run logger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,18 +58,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build
         run: cargo build
-
-  test:
-    needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Test
         env:
           RUST_BACKTRACE: 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,18 +56,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build
         run: cargo build
-
-  test:
-    needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Test
         env:
           RUST_BACKTRACE: 0

--- a/justfile
+++ b/justfile
@@ -58,17 +58,3 @@ all:
     cargo fmt --all
     cargo clippy --all-targets
     cargo test
-
-sys-info:
-    @echo "os_family: {{ os_family() }}"
-    @echo "os: {{ os() }}"
-    @echo "arch: {{ arch() }}"
-
-arch-specific:
-    just {{ if arch() == "aarch64" { "arm-stuff" } else { "x86-stuff" } }}
-
-@arm-stuff:
-    echo "arm!"
-
-@x86-stuff:
-    echo "x86!"

--- a/src/merge/log.rs
+++ b/src/merge/log.rs
@@ -1,8 +1,10 @@
 use super::behaviours::RunBehaviours;
+use crate::config::Config;
 use crate::domain::{
-    Disqualification, MergeResult, MergedPR, Qualification, RepoResult, RunSummary,
+    Disqualification, GhApiQueryParam, MergeResult, MergedPR, Qualification, RepoResult, RunSummary,
 };
 use anyhow::Context;
+use chrono::{DateTime, Utc};
 use colored::Colorize;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -13,16 +15,16 @@ const HEAD: &str = "[ head  ]  ";
 const CHECK: &str = "[ check  ]  ";
 const STATE: &str = "[ state  ]  ";
 
-pub(super) struct RunLog<W: Write> {
+pub(super) struct RunLogger<W: Write> {
     w: W,
     behaviours: RunBehaviours,
     lines: Vec<String>,
     summary: RunSummary,
 }
 
-impl<W: Write> RunLog<W> {
+impl<W: Write> RunLogger<W> {
     pub(super) fn new(writer: W, behaviours: &RunBehaviours) -> Self {
-        RunLog {
+        RunLogger {
             w: writer,
             behaviours: behaviours.clone(),
             lines: vec![],
@@ -190,7 +192,7 @@ Disqualifications
         Ok(())
     }
 
-    pub(super) fn banner(&mut self) {
+    pub(super) fn print_banner(&mut self) {
         let banner_output = if self.behaviours.plain_stdout {
             BANNER
         } else {
@@ -221,7 +223,50 @@ Disqualifications
         }
     }
 
-    pub(super) fn info(&mut self, message: &str) {
+    pub(super) fn print_startup_info(&mut self, config: &Config, now: DateTime<Utc>) {
+        self.info(&format!("The time right now is {now}"));
+
+        if let Some(b) = &config.base_branch {
+            self.info(&format!(
+                "I'm only looking for PRs where the base branch is \"{b}\""
+            ));
+        }
+
+        if config.merge_if_blocked {
+            self.info("I will merge PRs even if they're blocked");
+        }
+
+        if !config.merge_if_checks_skipped {
+            self.info("I won't merge PRs if checks are skipped");
+        }
+
+        if self.behaviours.show_repos_with_no_prs {
+            self.info("I will show repositories that have no PRs");
+        }
+
+        if self.behaviours.show_prs_from_untrusted_authors {
+            self.info("I will show PRs from untrusted authors");
+        }
+
+        if self.behaviours.show_prs_with_unmatched_head && config.head_pattern.is_some() {
+            self.info("I will show PRs from where head doesn't match configured head pattern");
+        }
+
+        self.info(&format!(
+            r#"I'm sorting PRs based on "{}" in the "{}" direction"#,
+            config.sort_by.readable_repr(),
+            config.sort_direction.readable_repr()
+        ));
+    }
+
+    pub(super) fn print_conclusion(&mut self, now: DateTime<Utc>, num_seconds: i64) {
+        self.empty_line();
+        self.info(&format!(
+            "This run ended at {now}; took {num_seconds} seconds"
+        ));
+    }
+
+    fn info(&mut self, message: &str) {
         let _ = writeln!(self.w, "[INFO] {message}");
 
         if self.behaviours.output_path.is_some() {
@@ -229,7 +274,7 @@ Disqualifications
         }
     }
 
-    pub(super) fn empty_line(&mut self) {
+    fn empty_line(&mut self) {
         let _ = writeln!(self.w);
 
         if self.behaviours.output_path.is_some() {

--- a/src/merge/mod.rs
+++ b/src/merge/mod.rs
@@ -5,14 +5,14 @@ mod log;
 mod tests;
 
 use crate::config::Config;
-use crate::domain::{GhApiQueryParam, Repo};
+use crate::domain::Repo;
 use anyhow::Context;
 pub use behaviours::RunBehaviours;
 use chrono::Utc;
 use execute::merge_pr_for_repo;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
-use log::RunLog;
+use log::RunLogger;
 use octocrab::Octocrab;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -25,7 +25,7 @@ pub async fn merge_prs(
     repos_override: Vec<Repo>,
     behaviours: RunBehaviours,
 ) -> anyhow::Result<()> {
-    let mut l = RunLog::new(std::io::stdout(), &behaviours);
+    let mut logger = RunLogger::new(std::io::stdout(), &behaviours);
 
     let repos_to_use = if repos_override.is_empty() {
         config.repos.clone()
@@ -37,42 +37,9 @@ pub async fn merge_prs(
         return Ok(());
     }
 
-    l.banner();
-
+    logger.print_banner();
     let start = Utc::now();
-    l.info(&format!("The time right now is {start}"));
-
-    if let Some(b) = &config.base_branch {
-        l.info(&format!(
-            "I'm only looking for PRs where the base branch is \"{b}\""
-        ));
-    }
-
-    if config.merge_if_blocked {
-        l.info("I will merge PRs even if they're blocked");
-    }
-
-    if !config.merge_if_checks_skipped {
-        l.info("I won't merge PRs if checks are skipped");
-    }
-
-    if behaviours.show_repos_with_no_prs {
-        l.info("I will show repositories that have no PRs");
-    }
-
-    if behaviours.show_prs_from_untrusted_authors {
-        l.info("I will show PRs from untrusted authors");
-    }
-
-    if behaviours.show_prs_with_unmatched_head && config.head_pattern.is_some() {
-        l.info("I will show PRs from where head doesn't match configured head pattern");
-    }
-
-    l.info(&format!(
-        r#"I'm sorting PRs based on "{}" in the "{}" direction"#,
-        config.sort_by.readable_repr(),
-        config.sort_direction.readable_repr()
-    ));
+    logger.print_startup_info(&config, start);
 
     let config = Arc::new(config);
 
@@ -89,18 +56,16 @@ pub async fn merge_prs(
 
     while let Some(result) = futures.next().await {
         let result = result.context("couldn't join merge task")?;
-        l.add_repo_result(result);
+        logger.add_repo_result(result);
     }
 
     let end_ts = Utc::now();
     let num_seconds = (end_ts - start).num_seconds();
+    logger.print_conclusion(end_ts, num_seconds);
 
-    l.empty_line();
-    l.info(&format!(
-        "This run ended at {end_ts}; took {num_seconds} seconds"
-    ));
-
-    l.write_output().context("couldn't write output to file")?;
+    logger
+        .write_output()
+        .context("couldn't write output to file")?;
 
     Ok(())
 }

--- a/src/merge/tests/log.rs
+++ b/src/merge/tests/log.rs
@@ -1,5 +1,5 @@
 use super::super::behaviours::RunBehaviours;
-use super::super::log::RunLog;
+use super::super::log::RunLogger;
 use crate::domain::{Disqualification, MergeResult, Qualification, RepoResult};
 use crate::domain::{
     PRCheck, PRCheckFinished, PRDisqualified, RepoCheck, RepoCheckErrored, RepoCheckFinished,
@@ -18,7 +18,7 @@ const PR_AUTHOR: &str = "dependabot[bot]";
 fn failed_repo_result_is_printed_correctly() {
     // GIVEN
     let mut buffer = vec![];
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -50,7 +50,7 @@ fn pr_with_unmatched_head_is_ignored_by_default() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -71,7 +71,7 @@ fn pr_with_unmatched_head_is_printed_if_requested() {
     let mut buffer = vec![];
 
     let behaviours = RunBehaviours::default().show_prs_with_unmatched_head();
-    let mut l = RunLog::new(&mut buffer, &behaviours);
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -107,7 +107,7 @@ fn pr_with_unknown_author_is_ignored_by_default() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -128,7 +128,7 @@ fn pr_with_unknown_author_is_printed_if_requested() {
     let mut buffer = vec![];
 
     let behaviours = RunBehaviours::default().show_prs_from_untrusted_authors();
-    let mut l = RunLog::new(&mut buffer, &behaviours);
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -165,7 +165,7 @@ fn pr_with_untrusted_author_is_ignored_by_default() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -186,7 +186,7 @@ fn pr_with_untrusted_author_is_printed_if_requested() {
     let mut buffer = vec![];
 
     let behaviours = RunBehaviours::default().show_prs_from_untrusted_authors();
-    let mut l = RunLog::new(&mut buffer, &behaviours);
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -223,7 +223,7 @@ fn pr_with_empty_check_conclusion_is_printed_correctly() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -266,7 +266,7 @@ fn pr_with_a_failed_check_is_printed_correctly() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -307,7 +307,7 @@ fn pr_with_unknown_state_is_printed_correctly() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -348,7 +348,7 @@ fn pr_with_an_undesirable_state_is_printed_correctly() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -389,7 +389,7 @@ fn pr_with_a_finished_check_is_printed_correctly() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -431,7 +431,7 @@ fn printing_summary_works() {
     // GIVEN
     let mut buffer = vec![];
 
-    let mut l = RunLog::new(&mut buffer, &RunBehaviours::default());
+    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -493,7 +493,7 @@ fn disqualifications_can_be_skipped_in_summary_when_requested() {
 
     let behaviours = RunBehaviours::default().skip_disqualifications_in_summary();
 
-    let mut l = RunLog::new(&mut buffer, &behaviours);
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -549,7 +549,7 @@ fn summary_includes_dq_that_are_ignored_by_default_if_requested() {
         .show_prs_with_unmatched_head()
         .show_prs_from_untrusted_authors();
 
-    let mut l = RunLog::new(&mut buffer, &behaviours);
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -614,7 +614,7 @@ fn summary_doesnt_include_dq_if_none_exist() {
 
     let behaviours = RunBehaviours::default().skip_disqualifications_in_summary();
 
-    let mut l = RunLog::new(&mut buffer, &behaviours);
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),
@@ -659,7 +659,7 @@ fn disqualification_reasons_are_left_aligned_in_summary() {
 
     let behaviours = RunBehaviours::default().show_prs_with_unmatched_head();
 
-    let mut l = RunLog::new(&mut buffer, &behaviours);
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
     let repo_check = RepoCheck {
         owner: OWNER.to_string(),
         name: REPO.to_string(),


### PR DESCRIPTION
Encapsulate printing logic into `RunLogger`, making `merge_prs` a bit cleaner.
