### PR TITLE
improve HTML report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "open",
  "regex",
  "serde",
+ "serde_json",
  "tera",
  "tokio",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = "0.4.43"
+chrono = { version = "0.4.43", features = ["serde"] }
 clap = { version = "4.5.56", features = ["derive"] }
 colored = "3"
 futures = "0.3.31"
@@ -29,6 +29,7 @@ octocrab = "0.49.7"
 open = "5.3.3"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tera = "1.20.1"
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
 toml = { version = "1.1.2", features = ["parse"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -35,15 +35,15 @@ pub enum MrjCommand {
             value_parser = validate_repo
             )]
         repos: Vec<Repo>,
-        /// Whether to write mrj's log of events to a file
+        /// Whether to write run output to a file
         #[arg(long = "output-to-file", short = 'o')]
         output_to_file: bool,
-        /// File to write output to
+        /// File to write run output to
         #[arg(
             long = "output-path",
             value_name = "FILE",
-            default_value = "output.txt",
-            value_parser = validate_txt_path,
+            default_value = "output.json",
+            value_parser = validate_json_path,
         )]
         output_path: PathBuf,
         /// Whether to write merge summary to a file
@@ -113,7 +113,7 @@ pub enum ReportCommand {
             long = "output-path",
             short = 'p',
             value_name = "PATH",
-            default_value = "output.txt"
+            default_value = "output.json"
         )]
         output_path: PathBuf,
         /// Whether to open report in the browser
@@ -237,5 +237,13 @@ fn validate_txt_path(s: &str) -> Result<PathBuf, String> {
         Ok(PathBuf::from(s))
     } else {
         Err(String::from("file must have a .txt extension"))
+    }
+}
+
+fn validate_json_path(s: &str) -> Result<PathBuf, String> {
+    if s.ends_with(".json") {
+        Ok(PathBuf::from(s))
+    } else {
+        Err(String::from("file must have a .json extension"))
     }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -3,10 +3,8 @@ use octocrab::models::pulls::PullRequest;
 use octocrab::params::Direction;
 use octocrab::params::pulls::{MergeMethod, Sort};
 use regex::Regex;
-use serde::{
-    Deserialize, Deserializer,
-    de::{self, Visitor},
-};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer};
 use std::fmt::{self, Display};
 use std::path::PathBuf;
 
@@ -213,6 +211,7 @@ impl GhApiQueryParam<Direction> for SortDirection {
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum RepoResult {
     Finished(RepoCheck<RepoCheckFinished>),
     Errored(RepoCheck<RepoCheckErrored>),
@@ -229,9 +228,18 @@ impl RepoResult {
     }
 }
 
+#[derive(Debug)]
+pub struct RunMergeResults {
+    pub results: Vec<RepoResult>,
+    pub summary: RunSummary,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: DateTime<Utc>,
+}
+
 pub trait RepoCheckState: private::Sealed {}
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct RepoCheckInProgress(Vec<MergeResult>);
 impl private::Sealed for RepoCheckInProgress {}
 impl RepoCheckState for RepoCheckInProgress {}
@@ -246,12 +254,24 @@ impl RepoCheckErrored {
     }
 }
 
+#[cfg(test)]
+impl serde::Serialize for RepoCheckErrored {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct RepoCheckFinished(pub Vec<MergeResult>);
 impl private::Sealed for RepoCheckFinished {}
 impl RepoCheckState for RepoCheckFinished {}
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct RepoCheck<S: RepoCheckState> {
     pub owner: String,
     pub name: String,
@@ -295,6 +315,7 @@ impl RepoCheck<RepoCheckFinished> {
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct PRCheck<S: PRCheckState> {
     pub number: u64,
     pub title: String,
@@ -306,6 +327,7 @@ pub struct PRCheck<S: PRCheckState> {
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum MergeResult {
     Qualified(PRCheck<PRCheckFinished>),
     Disqualified(PRCheck<PRDisqualified>),
@@ -369,11 +391,13 @@ impl MergeResult {
 pub trait PRCheckState: private::Sealed {}
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct PRCheckInProgress;
 impl private::Sealed for PRCheckInProgress {}
 impl PRCheckState for PRCheckInProgress {}
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct PRDisqualified(pub Disqualification);
 impl private::Sealed for PRDisqualified {}
 impl PRCheckState for PRDisqualified {}
@@ -394,7 +418,18 @@ impl PRCheckErrored {
     }
 }
 
+#[cfg(test)]
+impl serde::Serialize for PRCheckErrored {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct PRCheckFinished;
 impl private::Sealed for PRCheckFinished {}
 impl PRCheckState for PRCheckFinished {}
@@ -459,61 +494,75 @@ impl PRCheck<PRCheckInProgress> {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct RunSummary {
-    pub num_repos: usize,
-    pub num_repos_with_no_prs: usize,
-    pub disqualifications: Vec<(String, String)>,
-    pub num_errors: u16,
-    pub prs_merged: Vec<MergedPR>,
-}
-
-impl RunSummary {
-    pub fn record_repo(&mut self) {
-        self.num_repos += 1;
-    }
-
-    pub fn record_repo_with_no_prs(&mut self) {
-        self.num_repos_with_no_prs += 1;
-    }
-
-    pub fn record_disqualification(&mut self, pr_url: &str, disqualification: &Disqualification) {
-        let disqualification_summary = match disqualification {
-            Disqualification::Head(_) => "head didn't match".to_string(),
-            Disqualification::Author(author) => match author {
-                Some(a) => format!("author {a} untrusted"),
-                None => "author unknown".to_string(),
-            },
-            Disqualification::Check { name, conclusion } => match conclusion {
-                Some(c) => format!("check {name}: {c}"),
-                None => format!("check {name}: unknown conclusion"),
-            },
-            Disqualification::State(state) => match state {
-                Some(s) => format!("state: {s}"),
-                None => "state: unknown".to_string(),
-            },
-        };
-
-        self.disqualifications
-            .push((pr_url.to_string(), disqualification_summary));
-    }
-
-    pub fn record_error(&mut self) {
-        self.num_errors += 1;
-    }
-
-    pub fn record_merged_pr(&mut self, pr: MergedPR) {
-        self.prs_merged.push(pr);
-    }
-}
-
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct MergedPR {
     pub repo: String,
     pub title: String,
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub struct RunDisqualification {
+    pub pr_url: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub struct RunSummary {
+    pub disqualifications: Vec<RunDisqualification>,
+    pub num_errors: u16,
+    pub prs_merged: Vec<MergedPR>,
+}
+
+impl RunSummary {
+    pub fn from_results(results: &[RepoResult], did_execute: bool) -> Self {
+        let mut num_errors = 0;
+        let mut disqualifications = vec![];
+        let mut prs_merged = vec![];
+
+        for result in results {
+            match result {
+                RepoResult::Errored(_) => {
+                    num_errors += 1;
+                }
+                RepoResult::Finished(repo_check) => {
+                    for merge_result in repo_check.results() {
+                        match merge_result {
+                            MergeResult::Qualified(pr_check) => {
+                                if did_execute {
+                                    prs_merged.push(MergedPR {
+                                        repo: result.name(),
+                                        title: pr_check.title.clone(),
+                                    });
+                                }
+                            }
+                            MergeResult::Disqualified(pr_check) => {
+                                disqualifications.push(RunDisqualification {
+                                    pr_url: pr_check.url.clone(),
+                                    reason: pr_check.state.reason().summary(),
+                                });
+                            }
+                            MergeResult::Errored(_) => {
+                                num_errors += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            disqualifications,
+            num_errors,
+            prs_merged,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum Qualification {
     Head(String),
     Author(String),
@@ -522,6 +571,7 @@ pub enum Qualification {
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum Disqualification {
     Head(String),
     Author(Option<String>),
@@ -532,12 +582,206 @@ pub enum Disqualification {
     State(Option<String>),
 }
 
+impl Disqualification {
+    pub fn summary(&self) -> String {
+        match self {
+            Disqualification::Head(_) => "head didn't match".to_string(),
+            Disqualification::Author(author) => match author {
+                Some(a) => format!("author untrusted: {a}"),
+                None => "author unknown".to_string(),
+            },
+            Disqualification::Check { name, conclusion } => match conclusion {
+                Some(c) => format!("check {name}: {c}"),
+                None => format!("check {name}: unknown conclusion"),
+            },
+            Disqualification::State(state) => match state {
+                Some(s) => format!("state: {s}"),
+                None => "state: unknown".to_string(),
+            },
+        }
+    }
+}
+
 pub struct ReportConfig {
     pub output_path: PathBuf,
     pub custom_template: Option<String>,
     pub title: String,
     pub num_runs: u8,
     pub open_report: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_yaml_snapshot;
+
+    const OWNER: &str = "dhth";
+    const REPO: &str = "mrj";
+    const PR_TITLE: &str = "build: bump clap from 4.5.39 to 4.5.40";
+    const PR_URL: &str = "https://github.com/dhth/mrj/pull/1";
+    const PR_HEAD: &str = "dependabot/cargo/clap-4.5.40";
+
+    #[test]
+    fn run_summary_works_as_expected() {
+        // GIVEN
+        let repo_result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![
+                merge_result_disqualified_unmatched_head(),
+                merge_result_disqualified_unknown_author(),
+                merge_result_disqualified_untrusted_author(),
+                merge_result_disqualified_check_with_unknown_conclusion(),
+                merge_result_disqualified_failed_check(),
+                merge_result_disqualified_unknown_state(),
+                merge_result_disqualified_dirty_state(),
+                merge_result_errored(),
+                merge_result_qualified(),
+            ]),
+        });
+
+        // WHEN
+        let summary = RunSummary::from_results(&[repo_result], true);
+
+        // THEN
+        assert_yaml_snapshot!(summary, @r#"
+        disqualifications:
+          - pr_url: "https://github.com/dhth/mrj/pull/1"
+            reason: "head didn't match"
+          - pr_url: "https://github.com/dhth/mrj/pull/1"
+            reason: author unknown
+          - pr_url: "https://github.com/dhth/mrj/pull/1"
+            reason: "author untrusted: untrusted-author"
+          - pr_url: "https://github.com/dhth/mrj/pull/1"
+            reason: "check lint: unknown conclusion"
+          - pr_url: "https://github.com/dhth/mrj/pull/1"
+            reason: "check lint: failure"
+          - pr_url: "https://github.com/dhth/mrj/pull/1"
+            reason: "state: unknown"
+          - pr_url: "https://github.com/dhth/mrj/pull/1"
+            reason: "state: dirty"
+        num_errors: 1
+        prs_merged:
+          - repo: dhth/mrj
+            title: "build: bump clap from 4.5.39 to 4.5.40"
+        "#);
+    }
+
+    fn merge_result_disqualified_unmatched_head() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![],
+            state: PRDisqualified(Disqualification::Head("improve-tests".to_string())),
+        })
+    }
+
+    fn merge_result_disqualified_unknown_author() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRDisqualified(Disqualification::Author(None)),
+        })
+    }
+
+    fn merge_result_disqualified_untrusted_author() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRDisqualified(Disqualification::Author(Some(
+                "untrusted-author".to_string(),
+            ))),
+        })
+    }
+
+    fn merge_result_disqualified_check_with_unknown_conclusion() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRDisqualified(Disqualification::Check {
+                name: "lint".to_string(),
+                conclusion: None,
+            }),
+        })
+    }
+
+    fn merge_result_disqualified_failed_check() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRDisqualified(Disqualification::Check {
+                name: "lint".to_string(),
+                conclusion: Some("failure".to_string()),
+            }),
+        })
+    }
+
+    fn merge_result_disqualified_unknown_state() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRDisqualified(Disqualification::State(None)),
+        })
+    }
+
+    fn merge_result_disqualified_dirty_state() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRDisqualified(Disqualification::State(Some("dirty".to_string()))),
+        })
+    }
+
+    fn merge_result_errored() -> MergeResult {
+        MergeResult::Errored(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRCheckErrored(anyhow::anyhow!("couldn't merge PR: GitHub API was down")),
+        })
+    }
+
+    fn merge_result_qualified() -> MergeResult {
+        MergeResult::Qualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRCheckFinished,
+        })
+    }
 }
 
 mod private {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod auth;
 mod config;
 mod domain;
 mod merge;
+mod persistence;
 mod report;
 
 use anyhow::Context;
@@ -12,7 +13,9 @@ use auth::get_token;
 use clap::Parser;
 use config::get_config;
 use merge::{RunBehaviours, merge_prs};
+use persistence::persist_run;
 use report::generate_report;
+use std::sync::Arc;
 
 use crate::domain::ReportConfig;
 
@@ -42,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
             execute,
             plain_stdout,
         } => {
-            let config = get_config(config_file)?;
+            let config = Arc::new(get_config(config_file)?);
 
             if config.repos.is_empty() && repos.is_empty() {
                 anyhow::bail!("no repos to run for");
@@ -76,7 +79,16 @@ async fn main() -> anyhow::Result<()> {
                 execute,
                 plain_stdout,
             };
-            merge_prs(client, config, repos, run_behaviours).await?;
+
+            let Some(results) =
+                merge_prs(client, Arc::clone(&config), repos, run_behaviours.clone()).await?
+            else {
+                return Ok(());
+            };
+
+            if let Some(output_path) = run_behaviours.output_path.as_deref() {
+                persist_run(results, config.as_ref(), &run_behaviours, output_path)?;
+            }
         }
         MrjCommand::Config { config_command } => match config_command {
             ConfigCommand::Validate { config_file } => {

--- a/src/merge/log.rs
+++ b/src/merge/log.rs
@@ -1,7 +1,7 @@
 use super::behaviours::RunBehaviours;
 use crate::config::Config;
 use crate::domain::{
-    Disqualification, GhApiQueryParam, MergeResult, MergedPR, Qualification, RepoResult, RunSummary,
+    Disqualification, GhApiQueryParam, MergeResult, Qualification, RepoResult, RunSummary,
 };
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -18,8 +18,6 @@ const STATE: &str = "[ state  ]  ";
 pub(super) struct RunLogger<W: Write> {
     w: W,
     behaviours: RunBehaviours,
-    lines: Vec<String>,
-    summary: RunSummary,
 }
 
 impl<W: Write> RunLogger<W> {
@@ -27,14 +25,10 @@ impl<W: Write> RunLogger<W> {
         RunLogger {
             w: writer,
             behaviours: behaviours.clone(),
-            lines: vec![],
-            summary: RunSummary::default(),
         }
     }
 
-    pub(super) fn add_repo_result(&mut self, result: RepoResult) {
-        self.summary.record_repo();
-
+    pub(super) fn add_repo_result(&mut self, result: &RepoResult) {
         match &result {
             RepoResult::Errored(repo_check) => {
                 self.repo_info(&result.name());
@@ -42,52 +36,25 @@ impl<W: Write> RunLogger<W> {
                 self.error(repo_check.state.reason());
             }
             RepoResult::Finished(repo_check) => {
-                let filtered_results = repo_check
-                    .results()
-                    .iter()
-                    .filter(|result| match result {
-                        MergeResult::Disqualified(pr_check) => match pr_check.state.reason() {
-                            Disqualification::Author(_)
-                                if !self.behaviours.show_prs_from_untrusted_authors =>
-                            {
-                                false
-                            }
-                            Disqualification::Head(_)
-                                if !self.behaviours.show_prs_with_unmatched_head =>
-                            {
-                                false
-                            }
-                            _ => true,
-                        },
-                        _ => true,
-                    })
-                    .collect::<Vec<_>>();
-
-                if filtered_results.is_empty() {
-                    self.summary.record_repo_with_no_prs();
-                    if !self.behaviours.show_repos_with_no_prs {
-                        return;
-                    }
-                }
-
                 let repo = &result.name();
                 self.repo_info(repo);
 
-                if filtered_results.is_empty() {
+                if repo_check.results().is_empty() {
                     self.empty_line();
                     self.absence("no PRs");
                     return;
                 }
 
-                filtered_results
+                repo_check
+                    .results()
                     .iter()
-                    .for_each(|r| self.add_merge_result(r, repo));
+                    .for_each(|r| self.add_merge_result(r));
             }
         }
     }
 
-    pub(super) fn write_output(&mut self) -> anyhow::Result<()> {
-        let prs_merged = if self.summary.prs_merged.is_empty() {
+    pub(super) fn write_output(&mut self, summary: &RunSummary) -> anyhow::Result<()> {
+        let prs_merged = if summary.prs_merged.is_empty() {
             None
         } else {
             Some(format!(
@@ -97,7 +64,7 @@ PRs merged
 ---
 
 {}"#,
-                self.summary
+                summary
                     .prs_merged
                     .iter()
                     .map(|pr| format!("- [{}] {}", pr.repo, pr.title))
@@ -107,11 +74,10 @@ PRs merged
         };
 
         let disqualifications_summary = if !self.behaviours.skip_disqualifications_in_summary
-            && !self.summary.disqualifications.is_empty()
+            && !summary.disqualifications.is_empty()
         {
             let longest_url_len = self
-                .summary
-                .disqualifications
+                .disqualifications(summary)
                 .iter()
                 .map(|(p, _)| p.len())
                 .max()
@@ -124,8 +90,7 @@ Disqualifications
 ---
 
 {}"#,
-                self.summary
-                    .disqualifications
+                self.disqualifications(summary)
                     .iter()
                     .map(|(u, d)| format!("- {u:<longest_url_len$}        {d}"))
                     .collect::<Vec<_>>()
@@ -143,14 +108,10 @@ Disqualifications
 
 - PRs merged:                    {}
 - PRs disqualified:              {}
-- Repos checked:                 {}
-- Repos with no relevant PRs:    {}
 - Errors encountered:            {}{}{}"#,
-            self.summary.prs_merged.len(),
-            self.summary.disqualifications.len(),
-            self.summary.num_repos,
-            self.summary.num_repos_with_no_prs,
-            self.summary.num_errors,
+            summary.prs_merged.len(),
+            summary.disqualifications.len(),
+            summary.num_errors,
             prs_merged.unwrap_or_default(),
             disqualifications_summary.unwrap_or_default(),
         );
@@ -162,20 +123,6 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "{output}");
-
-        if let Some(output_path) = &self.behaviours.output_path {
-            self.lines.push(summary.clone());
-
-            let mut file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(output_path.as_path())
-                .context("couldn't open a handle to the output file")?;
-
-            file.write_all(self.lines.join("\n").as_bytes())
-                .context("couldn't write output to file")?;
-        }
 
         if let Some(summary_path) = &self.behaviours.summary_path {
             let mut file = OpenOptions::new()
@@ -213,14 +160,14 @@ Disqualifications
         }
 
         let _ = writeln!(self.w);
+    }
 
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(BANNER.to_string());
-            if !self.behaviours.execute {
-                self.lines.push(dry_run_line);
-            }
-            self.lines.push("".to_string());
-        }
+    fn disqualifications<'a>(&self, summary: &'a RunSummary) -> Vec<(&'a str, &'a str)> {
+        summary
+            .disqualifications
+            .iter()
+            .map(|dq| (dq.pr_url.as_str(), dq.reason.as_str()))
+            .collect()
     }
 
     pub(super) fn print_startup_info(&mut self, config: &Config, now: DateTime<Utc>) {
@@ -268,21 +215,13 @@ Disqualifications
 
     fn info(&mut self, message: &str) {
         let _ = writeln!(self.w, "[INFO] {message}");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(format!("[INFO] {message}"));
-        }
     }
 
     fn empty_line(&mut self) {
         let _ = writeln!(self.w);
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push("".to_string());
-        }
     }
 
-    fn add_merge_result(&mut self, result: &MergeResult, repo: &str) {
+    fn add_merge_result(&mut self, result: &MergeResult) {
         self.pr_info(&format!(
             r#"
 -> checking PR #{}
@@ -314,17 +253,13 @@ Disqualifications
 
         match result {
             MergeResult::Disqualified(pr_check) => {
-                self.disqualification(&pr_check.url, pr_check.state.reason());
+                self.disqualification(pr_check.state.reason());
             }
             MergeResult::Errored(pr_check) => {
                 self.error(pr_check.state.reason());
             }
             MergeResult::Qualified(_) => {
-                let merged_pr = MergedPR {
-                    repo: repo.to_string(),
-                    title: result.pr_title().to_string(),
-                };
-                self.merge(merged_pr);
+                self.merge();
             }
         }
     }
@@ -345,10 +280,6 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "{output}");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(line);
-        }
     }
 
     fn pr_info(&mut self, msg: &str) {
@@ -359,10 +290,6 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "{output}");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(msg.to_string());
-        }
     }
 
     fn qualification(&mut self, q: &Qualification) {
@@ -386,13 +313,9 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "        {output}");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(format!("        {msg}"));
-        }
     }
 
-    fn disqualification(&mut self, pr_url: &str, dq: &Disqualification) {
+    fn disqualification(&mut self, dq: &Disqualification) {
         let msg = match dq {
             Disqualification::Head(h) => {
                 format!("{HEAD} \"{h}\" doesn't match the allowed head pattern")
@@ -424,12 +347,6 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "        {output} ❌");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(format!("        {msg} ❌"));
-        }
-
-        self.summary.record_disqualification(pr_url, dq);
     }
 
     fn absence(&mut self, msg: &str) {
@@ -440,13 +357,9 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "        {output}");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(format!("        {msg}"));
-        }
     }
 
-    fn merge(&mut self, pr: MergedPR) {
+    fn merge(&mut self) {
         let msg = if self.behaviours.execute {
             "PR merged! 🎉 ✅"
         } else {
@@ -460,14 +373,6 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "        {output}");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(format!("        {msg}"));
-        }
-
-        if self.behaviours.execute {
-            self.summary.record_merged_pr(pr);
-        }
     }
 
     fn error(&mut self, error: &anyhow::Error) {
@@ -479,11 +384,5 @@ Disqualifications
         };
 
         let _ = writeln!(self.w, "{output}");
-
-        if self.behaviours.output_path.is_some() {
-            self.lines.push(line);
-        }
-
-        self.summary.record_error();
     }
 }

--- a/src/merge/mod.rs
+++ b/src/merge/mod.rs
@@ -1,71 +1,9 @@
 mod behaviours;
-mod execute;
 mod log;
+mod process;
+mod run;
 #[cfg(test)]
 mod tests;
 
-use crate::config::Config;
-use crate::domain::Repo;
-use anyhow::Context;
 pub use behaviours::RunBehaviours;
-use chrono::Utc;
-use execute::merge_pr_for_repo;
-use futures::StreamExt;
-use futures::stream::FuturesUnordered;
-use log::RunLogger;
-use octocrab::Octocrab;
-use std::sync::Arc;
-use tokio::sync::Semaphore;
-
-const MAX_FETCH_TASKS: usize = 50;
-
-pub async fn merge_prs(
-    client: Arc<Octocrab>,
-    config: Config,
-    repos_override: Vec<Repo>,
-    behaviours: RunBehaviours,
-) -> anyhow::Result<()> {
-    let mut logger = RunLogger::new(std::io::stdout(), &behaviours);
-
-    let repos_to_use = if repos_override.is_empty() {
-        config.repos.clone()
-    } else {
-        repos_override
-    };
-
-    if repos_to_use.is_empty() {
-        return Ok(());
-    }
-
-    logger.print_banner();
-    let start = Utc::now();
-    logger.print_startup_info(&config, start);
-
-    let config = Arc::new(config);
-
-    let semaphore = Arc::new(Semaphore::new(MAX_FETCH_TASKS));
-    let mut futures = FuturesUnordered::new();
-    for repo in repos_to_use {
-        let semaphore = Arc::clone(&semaphore);
-        let client = Arc::clone(&client);
-        let config = Arc::clone(&config);
-        futures.push(tokio::task::spawn(async move {
-            merge_pr_for_repo(semaphore, client, config, repo.clone(), behaviours.execute).await
-        }));
-    }
-
-    while let Some(result) = futures.next().await {
-        let result = result.context("couldn't join merge task")?;
-        logger.add_repo_result(result);
-    }
-
-    let end_ts = Utc::now();
-    let num_seconds = (end_ts - start).num_seconds();
-    logger.print_conclusion(end_ts, num_seconds);
-
-    logger
-        .write_output()
-        .context("couldn't write output to file")?;
-
-    Ok(())
-}
+pub(crate) use run::merge_prs;

--- a/src/merge/process.rs
+++ b/src/merge/process.rs
@@ -15,14 +15,12 @@ use tokio::sync::Semaphore;
 pub(super) async fn merge_pr_for_repo(
     semaphore: Arc<Semaphore>,
     client: Arc<Octocrab>,
-    config: Arc<Config>,
+    config: &Config,
     repo: Repo,
     execute: bool,
 ) -> RepoResult {
     let mut repo_check = RepoCheck::new(&repo.owner, &repo.repo);
 
-    // acquiring of the semaphore permit is done inside this function
-    // so that an error, if any, can be reported in the log
     match semaphore
         .acquire()
         .await
@@ -58,15 +56,13 @@ pub(super) async fn merge_pr_for_repo(
         return RepoResult::Finished(repo_check.finish());
     }
 
-    // This cannot be run concurrently as we only want to merge 1 PR for a
-    // repo in a run
     for pull_request in &page {
         let merge_result = merge_pr(
             &repo.owner,
             &repo.repo,
             pull_request,
             client.as_ref(),
-            config.as_ref(),
+            config,
             execute,
         )
         .await;
@@ -74,7 +70,6 @@ pub(super) async fn merge_pr_for_repo(
         repo_check.add_merge_result(merge_result);
 
         if no_failure {
-            // PR was merged
             break;
         }
     }

--- a/src/merge/run.rs
+++ b/src/merge/run.rs
@@ -1,0 +1,407 @@
+use crate::config::Config;
+use crate::domain::{
+    Disqualification, MergeResult, Repo, RepoCheck, RepoCheckFinished, RepoResult, RunMergeResults,
+    RunSummary,
+};
+use crate::merge::RunBehaviours;
+use crate::merge::log::RunLogger;
+use crate::merge::process::merge_pr_for_repo;
+use anyhow::Context;
+use chrono::Utc;
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
+use octocrab::Octocrab;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+const MAX_FETCH_TASKS: usize = 50;
+
+pub(crate) async fn merge_prs(
+    client: Arc<Octocrab>,
+    config: Arc<Config>,
+    repos_override: Vec<Repo>,
+    behaviours: RunBehaviours,
+) -> anyhow::Result<Option<RunMergeResults>> {
+    let mut logger = RunLogger::new(std::io::stdout(), &behaviours);
+    let mut results = vec![];
+
+    let repos_to_use = if repos_override.is_empty() {
+        config.repos.clone()
+    } else {
+        repos_override
+    };
+
+    if repos_to_use.is_empty() {
+        return Ok(None);
+    }
+
+    let started_at = Utc::now();
+    logger.print_banner();
+    logger.print_startup_info(config.as_ref(), started_at);
+
+    let semaphore = Arc::new(Semaphore::new(MAX_FETCH_TASKS));
+    let mut futures = FuturesUnordered::new();
+    for repo in repos_to_use {
+        let semaphore = Arc::clone(&semaphore);
+        let client = Arc::clone(&client);
+        let config = Arc::clone(&config);
+        futures.push(tokio::task::spawn(async move {
+            merge_pr_for_repo(semaphore, client, config.as_ref(), repo, behaviours.execute).await
+        }));
+    }
+
+    while let Some(result) = futures.next().await {
+        let result = result.context("couldn't join merge task")?;
+
+        if let Some(result) = filter_repo_result(result, &behaviours) {
+            logger.add_repo_result(&result);
+            results.push(result);
+        }
+    }
+    let summary = RunSummary::from_results(&results, behaviours.execute);
+
+    let ended_at = Utc::now();
+    let num_seconds = (ended_at - started_at).num_seconds();
+    logger.print_conclusion(ended_at, num_seconds);
+
+    logger
+        .write_output(&summary)
+        .context("couldn't write output to file")?;
+
+    Ok(Some(RunMergeResults {
+        results,
+        summary,
+        started_at,
+        ended_at,
+    }))
+}
+
+fn filter_repo_result(result: RepoResult, behaviours: &RunBehaviours) -> Option<RepoResult> {
+    match result {
+        RepoResult::Errored(repo_check) => Some(RepoResult::Errored(repo_check)),
+        RepoResult::Finished(RepoCheck {
+            owner,
+            name,
+            state: RepoCheckFinished(results),
+        }) => {
+            let filtered_results = results
+                .into_iter()
+                .filter(|result| should_show_merge_result(result, behaviours))
+                .collect::<Vec<_>>();
+
+            if filtered_results.is_empty() && !behaviours.show_repos_with_no_prs {
+                return None;
+            }
+
+            Some(RepoResult::Finished(RepoCheck {
+                owner,
+                name,
+                state: RepoCheckFinished(filtered_results),
+            }))
+        }
+    }
+}
+
+fn should_show_merge_result(result: &MergeResult, behaviours: &RunBehaviours) -> bool {
+    match result {
+        MergeResult::Disqualified(pr_check) => match pr_check.state.reason() {
+            Disqualification::Author(_) if !behaviours.show_prs_from_untrusted_authors => false,
+            Disqualification::Head(_) if !behaviours.show_prs_with_unmatched_head => false,
+            _ => true,
+        },
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{PRCheck, PRCheckErrored, PRCheckFinished, PRDisqualified, Qualification};
+    use insta::assert_yaml_snapshot;
+
+    const OWNER: &str = "dhth";
+    const REPO: &str = "mrj";
+    const PR_TITLE: &str = "build: bump clap from 4.5.39 to 4.5.40";
+    const PR_URL: &str = "https://github.com/dhth/mrj/pull/1";
+    const PR_HEAD: &str = "dependabot/cargo/clap-4.5.40";
+
+    #[test]
+    fn filtering_repo_result_keeps_qualified_prs() {
+        // GIVEN
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![merge_result_qualified()]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &RunBehaviours::default());
+
+        // THEN
+        assert_yaml_snapshot!(filtered_result, @r#"
+        Finished:
+          owner: dhth
+          name: mrj
+          state:
+            - Qualified:
+                number: 3
+                title: "build: bump clap from 4.5.39 to 4.5.40"
+                url: "https://github.com/dhth/mrj/pull/1"
+                pr_created_at: ~
+                pr_updated_at: ~
+                qualifications:
+                  - Head: dependabot/cargo/clap-4.5.40
+                state: ~
+        "#
+        );
+    }
+
+    #[test]
+    fn filtering_repo_result_passes_through_errored_repo_results() {
+        // GIVEN
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![merge_result_errored()]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &RunBehaviours::default());
+
+        // THEN
+        assert_yaml_snapshot!(filtered_result, @r#"
+        Finished:
+          owner: dhth
+          name: mrj
+          state:
+            - Errored:
+                number: 4
+                title: "build: bump clap from 4.5.39 to 4.5.40"
+                url: "https://github.com/dhth/mrj/pull/1"
+                pr_created_at: ~
+                pr_updated_at: ~
+                qualifications:
+                  - Head: dependabot/cargo/clap-4.5.40
+                state: "couldn't merge PR: GitHub API was down"
+        "#
+        );
+    }
+
+    #[test]
+    fn filtering_repo_result_filters_out_head_disqualified_prs_by_default() {
+        // GIVEN
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![merge_result_disqualified_unmatched_head()]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &RunBehaviours::default());
+
+        // THEN
+        assert!(filtered_result.is_none());
+    }
+
+    #[test]
+    fn filtering_repo_result_filters_out_author_disqualified_prs_by_default() {
+        // GIVEN
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![merge_result_disqualified_untrusted_author()]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &RunBehaviours::default());
+
+        // THEN
+        assert!(filtered_result.is_none());
+    }
+
+    #[test]
+    fn filtering_repo_result_keeps_head_disqualified_prs_when_requested() {
+        // GIVEN
+        let behaviours = RunBehaviours::default().show_prs_with_unmatched_head();
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![merge_result_disqualified_unmatched_head()]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &behaviours);
+
+        // THEN
+        assert_yaml_snapshot!(filtered_result, @r#"
+        Finished:
+          owner: dhth
+          name: mrj
+          state:
+            - Disqualified:
+                number: 1
+                title: "build: bump clap from 4.5.39 to 4.5.40"
+                url: "https://github.com/dhth/mrj/pull/1"
+                pr_created_at: ~
+                pr_updated_at: ~
+                qualifications: []
+                state:
+                  Head: big-refactor
+        "#
+        );
+    }
+
+    #[test]
+    fn filtering_repo_result_keeps_author_disqualified_prs_when_requested() {
+        // GIVEN
+        let behaviours = RunBehaviours::default().show_prs_from_untrusted_authors();
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![merge_result_disqualified_untrusted_author()]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &behaviours);
+
+        // THEN
+        assert_yaml_snapshot!(filtered_result, @r#"
+        Finished:
+          owner: dhth
+          name: mrj
+          state:
+            - Disqualified:
+                number: 2
+                title: "build: bump clap from 4.5.39 to 4.5.40"
+                url: "https://github.com/dhth/mrj/pull/1"
+                pr_created_at: ~
+                pr_updated_at: ~
+                qualifications:
+                  - Head: dependabot/cargo/clap-4.5.40
+                state:
+                  Author: untrusted-author
+        "#
+        );
+    }
+
+    #[test]
+    fn filtering_repo_result_keeps_repo_with_empty_results_when_requested() {
+        // GIVEN
+        let behaviours = RunBehaviours {
+            show_repos_with_no_prs: true,
+            ..RunBehaviours::default()
+        };
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![merge_result_disqualified_unmatched_head()]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &behaviours);
+
+        // THEN
+        assert_yaml_snapshot!(filtered_result, @"
+        Finished:
+          owner: dhth
+          name: mrj
+          state: []
+        "
+        );
+    }
+
+    #[test]
+    fn filtering_repo_result_keeps_only_visible_results_in_mixed_repo_results() {
+        // GIVEN
+        let result = RepoResult::Finished(RepoCheck {
+            owner: OWNER.to_string(),
+            name: REPO.to_string(),
+            state: RepoCheckFinished(vec![
+                merge_result_disqualified_unmatched_head(),
+                merge_result_disqualified_untrusted_author(),
+                merge_result_errored(),
+                merge_result_qualified(),
+            ]),
+        });
+
+        // WHEN
+        let filtered_result = filter_repo_result(result, &RunBehaviours::default());
+
+        // THEN
+        assert_yaml_snapshot!(filtered_result, @r#"
+        Finished:
+          owner: dhth
+          name: mrj
+          state:
+            - Errored:
+                number: 4
+                title: "build: bump clap from 4.5.39 to 4.5.40"
+                url: "https://github.com/dhth/mrj/pull/1"
+                pr_created_at: ~
+                pr_updated_at: ~
+                qualifications:
+                  - Head: dependabot/cargo/clap-4.5.40
+                state: "couldn't merge PR: GitHub API was down"
+            - Qualified:
+                number: 3
+                title: "build: bump clap from 4.5.39 to 4.5.40"
+                url: "https://github.com/dhth/mrj/pull/1"
+                pr_created_at: ~
+                pr_updated_at: ~
+                qualifications:
+                  - Head: dependabot/cargo/clap-4.5.40
+                state: ~
+        "#
+        );
+    }
+
+    fn merge_result_disqualified_unmatched_head() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 1,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![],
+            state: PRDisqualified(Disqualification::Head("big-refactor".to_string())),
+        })
+    }
+
+    fn merge_result_disqualified_untrusted_author() -> MergeResult {
+        MergeResult::Disqualified(PRCheck {
+            number: 2,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRDisqualified(Disqualification::Author(Some(
+                "untrusted-author".to_string(),
+            ))),
+        })
+    }
+
+    fn merge_result_qualified() -> MergeResult {
+        MergeResult::Qualified(PRCheck {
+            number: 3,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRCheckFinished,
+        })
+    }
+
+    fn merge_result_errored() -> MergeResult {
+        MergeResult::Errored(PRCheck {
+            number: 4,
+            title: PR_TITLE.to_string(),
+            url: PR_URL.to_string(),
+            pr_created_at: None,
+            pr_updated_at: None,
+            qualifications: vec![Qualification::Head(PR_HEAD.to_string())],
+            state: PRCheckErrored(anyhow::anyhow!("couldn't merge PR: GitHub API was down")),
+        })
+    }
+}

--- a/src/merge/tests/log.rs
+++ b/src/merge/tests/log.rs
@@ -1,6 +1,8 @@
 use super::super::behaviours::RunBehaviours;
 use super::super::log::RunLogger;
-use crate::domain::{Disqualification, MergeResult, Qualification, RepoResult};
+use crate::domain::{
+    Disqualification, MergeResult, Qualification, RepoResult, RunDisqualification, RunSummary,
+};
 use crate::domain::{
     PRCheck, PRCheckFinished, PRDisqualified, RepoCheck, RepoCheckErrored, RepoCheckFinished,
 };
@@ -27,7 +29,7 @@ fn failed_repo_result_is_printed_correctly() {
     let repo_result = RepoResult::Errored(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -46,26 +48,6 @@ fn failed_repo_result_is_printed_correctly() {
 }
 
 #[test]
-fn pr_with_unmatched_head_is_ignored_by_default() {
-    // GIVEN
-    let mut buffer = vec![];
-
-    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![merge_result_disqualified_unmatched_head(1)]),
-    };
-    let repo_result = RepoResult::Finished(repo_check);
-
-    // WHEN
-    l.add_repo_result(repo_result);
-
-    // THEN
-    assert_eq!(buffer.len(), 0);
-}
-
-#[test]
 fn pr_with_unmatched_head_is_printed_if_requested() {
     // GIVEN
     let mut buffer = vec![];
@@ -80,7 +62,7 @@ fn pr_with_unmatched_head_is_printed_if_requested() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -103,26 +85,6 @@ fn pr_with_unmatched_head_is_printed_if_requested() {
 }
 
 #[test]
-fn pr_with_unknown_author_is_ignored_by_default() {
-    // GIVEN
-    let mut buffer = vec![];
-
-    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![merge_result_disqualified_untrusted_author()]),
-    };
-    let repo_result = RepoResult::Finished(repo_check);
-
-    // WHEN
-    l.add_repo_result(repo_result);
-
-    // THEN
-    assert_eq!(buffer.len(), 0);
-}
-
-#[test]
 fn pr_with_unknown_author_is_printed_if_requested() {
     // GIVEN
     let mut buffer = vec![];
@@ -137,7 +99,7 @@ fn pr_with_unknown_author_is_printed_if_requested() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -161,26 +123,6 @@ fn pr_with_unknown_author_is_printed_if_requested() {
 }
 
 #[test]
-fn pr_with_untrusted_author_is_ignored_by_default() {
-    // GIVEN
-    let mut buffer = vec![];
-
-    let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![merge_result_disqualified_untrusted_author()]),
-    };
-    let repo_result = RepoResult::Finished(repo_check);
-
-    // WHEN
-    l.add_repo_result(repo_result);
-
-    // THEN
-    assert_eq!(buffer.len(), 0);
-}
-
-#[test]
 fn pr_with_untrusted_author_is_printed_if_requested() {
     // GIVEN
     let mut buffer = vec![];
@@ -195,7 +137,7 @@ fn pr_with_untrusted_author_is_printed_if_requested() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -234,7 +176,7 @@ fn pr_with_empty_check_conclusion_is_printed_correctly() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -275,7 +217,7 @@ fn pr_with_a_failed_check_is_printed_correctly() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -316,7 +258,7 @@ fn pr_with_unknown_state_is_printed_correctly() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -357,7 +299,7 @@ fn pr_with_an_undesirable_state_is_printed_correctly() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -398,7 +340,7 @@ fn pr_with_a_finished_check_is_printed_correctly() {
     let repo_result = RepoResult::Finished(repo_check);
 
     // WHEN
-    l.add_repo_result(repo_result);
+    l.add_repo_result(&repo_result);
 
     // THEN
     let out =
@@ -428,149 +370,13 @@ fn pr_with_a_finished_check_is_printed_correctly() {
 
 #[test]
 fn printing_summary_works() {
-    // GIVEN
     let mut buffer = vec![];
-
     let mut l = RunLogger::new(&mut buffer, &RunBehaviours::default());
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![
-            merge_result_disqualified_unmatched_head(1),
-            merge_result_disqualified_unknown_author(),
-            merge_result_disqualified_untrusted_author(),
-            merge_result_disqualified_check_with_unknown_conclusion(),
-            merge_result_disqualified_failed_check(),
-            merge_result_disqualified_unknown_state(),
-            merge_result_disqualified_dirty_state(),
-            merge_result_qualified(),
-        ]),
-    };
-    let repo_result = RepoResult::Finished(repo_check);
+    let summary = summary_with_disqualifications();
 
-    // WHEN
-    l.add_repo_result(repo_result);
-    l.write_output().expect("output should've been written");
+    l.write_output(&summary)
+        .expect("output should've been written");
 
-    // THEN
-    let out =
-        String::from_utf8(buffer).expect("buffer contents should've been converted to a string");
-
-    let (_, summary) = out
-        .split_once(
-            r#"
-===========
-  SUMMARY
-===========
-"#,
-        )
-        .expect("output should've been split by the summary header");
-
-    assert_snapshot!(
-        summary,
-        @r"
-        - PRs merged:                    0
-        - PRs disqualified:              4
-        - Repos checked:                 1
-        - Repos with no relevant PRs:    0
-        - Errors encountered:            0
-
-        Disqualifications
-        ---
-
-        - https://github.com/dhth/mrj/pull/1        check lint: unknown conclusion
-        - https://github.com/dhth/mrj/pull/1        check lint: failure
-        - https://github.com/dhth/mrj/pull/1        state: unknown
-        - https://github.com/dhth/mrj/pull/1        state: dirty
-        "
-    );
-}
-
-#[test]
-fn disqualifications_can_be_skipped_in_summary_when_requested() {
-    // GIVEN
-    let mut buffer = vec![];
-
-    let behaviours = RunBehaviours::default().skip_disqualifications_in_summary();
-
-    let mut l = RunLogger::new(&mut buffer, &behaviours);
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![
-            merge_result_disqualified_unmatched_head(1),
-            merge_result_disqualified_unknown_author(),
-            merge_result_disqualified_untrusted_author(),
-            merge_result_disqualified_check_with_unknown_conclusion(),
-            merge_result_disqualified_failed_check(),
-            merge_result_disqualified_unknown_state(),
-            merge_result_disqualified_dirty_state(),
-            merge_result_qualified(),
-        ]),
-    };
-    let repo_result = RepoResult::Finished(repo_check);
-
-    // WHEN
-    l.add_repo_result(repo_result);
-    l.write_output().expect("output should've been written");
-
-    // THEN
-    let out =
-        String::from_utf8(buffer).expect("buffer contents should've been converted to a string");
-
-    let (_, summary) = out
-        .split_once(
-            r#"
-===========
-  SUMMARY
-===========
-"#,
-        )
-        .expect("output should've been split by the summary header");
-
-    assert_snapshot!(
-        summary,
-        @r"
-        - PRs merged:                    0
-        - PRs disqualified:              4
-        - Repos checked:                 1
-        - Repos with no relevant PRs:    0
-        - Errors encountered:            0
-        "
-    );
-}
-
-#[test]
-fn summary_includes_dq_that_are_ignored_by_default_if_requested() {
-    // GIVEN
-    let mut buffer = vec![];
-
-    let behaviours = RunBehaviours::default()
-        .show_prs_with_unmatched_head()
-        .show_prs_from_untrusted_authors();
-
-    let mut l = RunLogger::new(&mut buffer, &behaviours);
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![
-            merge_result_disqualified_unmatched_head(1),
-            merge_result_disqualified_unknown_author(),
-            merge_result_disqualified_untrusted_author(),
-            merge_result_disqualified_check_with_unknown_conclusion(),
-            merge_result_disqualified_failed_check(),
-            merge_result_disqualified_unknown_state(),
-            merge_result_disqualified_dirty_state(),
-            merge_result_qualified(),
-        ]),
-    };
-    let repo_result = RepoResult::Finished(repo_check);
-
-    // WHEN
-    l.add_repo_result(repo_result);
-    l.write_output().expect("output should've been written");
-
-    // THEN
     let out =
         String::from_utf8(buffer).expect("buffer contents should've been converted to a string");
 
@@ -589,8 +395,6 @@ fn summary_includes_dq_that_are_ignored_by_default_if_requested() {
         @r"
         - PRs merged:                    0
         - PRs disqualified:              7
-        - Repos checked:                 1
-        - Repos with no relevant PRs:    0
         - Errors encountered:            0
 
         Disqualifications
@@ -608,25 +412,52 @@ fn summary_includes_dq_that_are_ignored_by_default_if_requested() {
 }
 
 #[test]
-fn summary_doesnt_include_dq_if_none_exist() {
-    // GIVEN
+fn disqualifications_can_be_skipped_in_summary_when_requested() {
     let mut buffer = vec![];
-
     let behaviours = RunBehaviours::default().skip_disqualifications_in_summary();
-
     let mut l = RunLogger::new(&mut buffer, &behaviours);
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![merge_result_qualified()]),
+    let summary = summary_with_disqualifications();
+
+    l.write_output(&summary)
+        .expect("output should've been written");
+
+    let out =
+        String::from_utf8(buffer).expect("buffer contents should've been converted to a string");
+
+    let (_, summary) = out
+        .split_once(
+            r#"
+===========
+  SUMMARY
+===========
+"#,
+        )
+        .expect("output should've been split by the summary header");
+
+    assert_snapshot!(
+        summary,
+        @r"
+        - PRs merged:                    0
+        - PRs disqualified:              7
+        - Errors encountered:            0
+        "
+    );
+}
+
+#[test]
+fn summary_doesnt_include_dq_if_none_exist() {
+    let mut buffer = vec![];
+    let behaviours = RunBehaviours::default().skip_disqualifications_in_summary();
+    let mut l = RunLogger::new(&mut buffer, &behaviours);
+    let summary = RunSummary {
+        disqualifications: vec![],
+        num_errors: 0,
+        prs_merged: vec![],
     };
-    let repo_result = RepoResult::Finished(repo_check);
 
-    // WHEN
-    l.add_repo_result(repo_result);
-    l.write_output().expect("output should've been written");
+    l.write_output(&summary)
+        .expect("output should've been written");
 
-    // THEN
     let out =
         String::from_utf8(buffer).expect("buffer contents should've been converted to a string");
 
@@ -645,8 +476,6 @@ fn summary_doesnt_include_dq_if_none_exist() {
         @r"
         - PRs merged:                    0
         - PRs disqualified:              0
-        - Repos checked:                 1
-        - Repos with no relevant PRs:    0
         - Errors encountered:            0
         "
     );
@@ -654,29 +483,23 @@ fn summary_doesnt_include_dq_if_none_exist() {
 
 #[test]
 fn disqualification_reasons_are_left_aligned_in_summary() {
-    // GIVEN
     let mut buffer = vec![];
-
-    let behaviours = RunBehaviours::default().show_prs_with_unmatched_head();
-
+    let behaviours = RunBehaviours::default();
     let mut l = RunLogger::new(&mut buffer, &behaviours);
-    let repo_check = RepoCheck {
-        owner: OWNER.to_string(),
-        name: REPO.to_string(),
-        state: RepoCheckFinished(vec![
-            merge_result_disqualified_unmatched_head(1),
-            merge_result_disqualified_unmatched_head(11),
-            merge_result_disqualified_unmatched_head(111),
-            merge_result_disqualified_unmatched_head(1111),
-        ]),
+    let summary = RunSummary {
+        disqualifications: vec![
+            run_disqualification(1, "head didn't match"),
+            run_disqualification(11, "head didn't match"),
+            run_disqualification(111, "head didn't match"),
+            run_disqualification(1111, "head didn't match"),
+        ],
+        num_errors: 0,
+        prs_merged: vec![],
     };
-    let repo_result = RepoResult::Finished(repo_check);
 
-    // WHEN
-    l.add_repo_result(repo_result);
-    l.write_output().expect("output should've been written");
+    l.write_output(&summary)
+        .expect("output should've been written");
 
-    // THEN
     let out =
         String::from_utf8(buffer).expect("buffer contents should've been converted to a string");
 
@@ -695,8 +518,6 @@ fn disqualification_reasons_are_left_aligned_in_summary() {
         @r"
         - PRs merged:                    0
         - PRs disqualified:              4
-        - Repos checked:                 1
-        - Repos with no relevant PRs:    0
         - Errors encountered:            0
 
         Disqualifications
@@ -888,6 +709,29 @@ fn merge_result_qualified() -> MergeResult {
         ],
         state: PRCheckFinished,
     })
+}
+
+fn summary_with_disqualifications() -> RunSummary {
+    RunSummary {
+        disqualifications: vec![
+            run_disqualification(1, "head didn't match"),
+            run_disqualification(1, "author unknown"),
+            run_disqualification(1, "author untrusted-dependabot[bot] untrusted"),
+            run_disqualification(1, "check lint: unknown conclusion"),
+            run_disqualification(1, "check lint: failure"),
+            run_disqualification(1, "state: unknown"),
+            run_disqualification(1, "state: dirty"),
+        ],
+        num_errors: 0,
+        prs_merged: vec![],
+    }
+}
+
+fn run_disqualification(number: u64, reason: &str) -> RunDisqualification {
+    RunDisqualification {
+        pr_url: format!("https://github.com/dhth/mrj/pull/{number}"),
+        reason: reason.to_string(),
+    }
 }
 
 fn created_at() -> DateTime<Utc> {

--- a/src/persistence/io.rs
+++ b/src/persistence/io.rs
@@ -1,0 +1,209 @@
+use super::schema::{
+    StoredDisqualification, StoredPrRecord, StoredPrStatus, StoredQualification, StoredRepoRecord,
+    StoredRepoStatus, StoredRunConfig, StoredRunData, StoredRunEnvelope, StoredRunFlags,
+    StoredRunMode, StoredRunSummary,
+};
+use crate::config::Config;
+use crate::domain::{
+    Disqualification, MergeResult, Qualification, RepoResult, RunMergeResults, RunSummary,
+};
+use crate::merge::RunBehaviours;
+use anyhow::Context;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+const RUN_OUTPUT_SCHEMA_VERSION: u16 = 1;
+
+pub fn persist_run(
+    results: RunMergeResults,
+    config: &Config,
+    behaviours: &RunBehaviours,
+    output_path: &Path,
+) -> anyhow::Result<()> {
+    let RunMergeResults {
+        results,
+        summary,
+        started_at,
+        ended_at: finished_at,
+    } = results;
+
+    let persisted_run = StoredRunEnvelope {
+        version: RUN_OUTPUT_SCHEMA_VERSION,
+        run: StoredRunData {
+            started_at,
+            finished_at,
+            took_ms: (finished_at - started_at).num_milliseconds(),
+            mode: if behaviours.execute {
+                StoredRunMode::Execute
+            } else {
+                StoredRunMode::DryRun
+            },
+            config: map_config(config, behaviours),
+            summary: map_summary(summary),
+            repos: results
+                .into_iter()
+                .map(|result| map_repo_result(result, behaviours.execute))
+                .collect(),
+        },
+    };
+
+    write_run(output_path, &persisted_run).with_context(|| {
+        format!(
+            "couldn't write persisted run to {}",
+            output_path.to_string_lossy()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn map_summary(summary: RunSummary) -> StoredRunSummary {
+    StoredRunSummary {
+        num_disqualifications: summary.disqualifications.len(),
+        num_errors: summary.num_errors,
+        num_merged: summary.prs_merged.len(),
+    }
+}
+
+fn map_config(config: &Config, behaviours: &RunBehaviours) -> StoredRunConfig {
+    StoredRunConfig {
+        base_branch: config.base_branch.clone(),
+        head_pattern: config
+            .head_pattern
+            .as_ref()
+            .map(|pattern| pattern.re.as_str().to_string()),
+        merge_if_blocked: config.merge_if_blocked,
+        merge_if_checks_skipped: config.merge_if_checks_skipped,
+        merge_type: (&config.merge_type).into(),
+        sort_by: (&config.sort_by).into(),
+        sort_direction: (&config.sort_direction).into(),
+        flags: StoredRunFlags {
+            show_repos_with_no_prs: behaviours.show_repos_with_no_prs,
+            show_prs_from_untrusted_authors: behaviours.show_prs_from_untrusted_authors,
+            show_prs_with_unmatched_head: behaviours.show_prs_with_unmatched_head,
+            skip_disqualifications_in_summary: behaviours.skip_disqualifications_in_summary,
+        },
+    }
+}
+
+fn map_repo_result(result: RepoResult, did_execute: bool) -> StoredRepoRecord {
+    match result {
+        RepoResult::Errored(repo_check) => StoredRepoRecord {
+            repo: format!("{}/{}", repo_check.owner, repo_check.name),
+            owner: repo_check.owner,
+            name: repo_check.name,
+            status: StoredRepoStatus::Errored,
+            error: Some(format!("{:#}", repo_check.state.reason())),
+            prs: vec![],
+        },
+        RepoResult::Finished(repo_check) => {
+            let repo = format!("{}/{}", repo_check.owner, repo_check.name);
+            StoredRepoRecord {
+                repo,
+                owner: repo_check.owner,
+                name: repo_check.name,
+                status: StoredRepoStatus::Finished,
+                error: None,
+                prs: repo_check
+                    .state
+                    .0
+                    .into_iter()
+                    .map(|result| map_pr_result(result, did_execute))
+                    .collect(),
+            }
+        }
+    }
+}
+
+fn map_pr_result(result: MergeResult, did_execute: bool) -> StoredPrRecord {
+    match result {
+        MergeResult::Qualified(pr_check) => StoredPrRecord {
+            number: pr_check.number,
+            title: pr_check.title,
+            url: pr_check.url,
+            created_at: pr_check.pr_created_at,
+            updated_at: pr_check.pr_updated_at,
+            status: StoredPrStatus::Qualified,
+            qualifications: pr_check
+                .qualifications
+                .into_iter()
+                .map(map_qualification)
+                .collect(),
+            disqualification: None,
+            error: None,
+            merged: did_execute,
+        },
+        MergeResult::Disqualified(pr_check) => StoredPrRecord {
+            number: pr_check.number,
+            title: pr_check.title,
+            url: pr_check.url,
+            created_at: pr_check.pr_created_at,
+            updated_at: pr_check.pr_updated_at,
+            status: StoredPrStatus::Disqualified,
+            qualifications: pr_check
+                .qualifications
+                .into_iter()
+                .map(map_qualification)
+                .collect(),
+            disqualification: Some(map_disqualification(pr_check.state.0)),
+            error: None,
+            merged: false,
+        },
+        MergeResult::Errored(pr_check) => StoredPrRecord {
+            number: pr_check.number,
+            title: pr_check.title,
+            url: pr_check.url,
+            created_at: pr_check.pr_created_at,
+            updated_at: pr_check.pr_updated_at,
+            status: StoredPrStatus::Errored,
+            qualifications: pr_check
+                .qualifications
+                .into_iter()
+                .map(map_qualification)
+                .collect(),
+            disqualification: None,
+            error: Some(format!("{:#}", pr_check.state.reason())),
+            merged: false,
+        },
+    }
+}
+
+fn map_qualification(qualification: Qualification) -> StoredQualification {
+    match qualification {
+        Qualification::Head(value) => StoredQualification::Head { value },
+        Qualification::Author(value) => StoredQualification::Author { value },
+        Qualification::Check { name, conclusion } => {
+            StoredQualification::Check { name, conclusion }
+        }
+        Qualification::State(value) => StoredQualification::State { value },
+    }
+}
+
+fn map_disqualification(disqualification: Disqualification) -> StoredDisqualification {
+    match disqualification {
+        Disqualification::Head(value) => StoredDisqualification::Head { value },
+        Disqualification::Author(value) => StoredDisqualification::Author { value },
+        Disqualification::Check { name, conclusion } => {
+            StoredDisqualification::Check { name, conclusion }
+        }
+        Disqualification::State(value) => StoredDisqualification::State { value },
+    }
+}
+
+fn write_run<P>(path: P, persisted_run: &StoredRunEnvelope) -> anyhow::Result<()>
+where
+    P: AsRef<Path>,
+{
+    let contents = serde_json::to_vec_pretty(persisted_run)
+        .context("couldn't serialize persisted run to JSON")?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)?;
+    file.write_all(&contents)?;
+    file.write_all(b"\n")?;
+
+    Ok(())
+}

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,0 +1,4 @@
+mod io;
+pub(crate) mod schema;
+
+pub use io::persist_run;

--- a/src/persistence/schema.rs
+++ b/src/persistence/schema.rs
@@ -1,0 +1,181 @@
+use crate::domain::{MergeType, SortBy, SortDirection};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StoredRunEnvelope {
+    pub version: u16,
+    pub run: StoredRunData,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StoredRunData {
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub took_ms: i64,
+    pub mode: StoredRunMode,
+    pub config: StoredRunConfig,
+    pub summary: StoredRunSummary,
+    pub repos: Vec<StoredRepoRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StoredRunSummary {
+    pub num_disqualifications: usize,
+    pub num_errors: u16,
+    pub num_merged: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoredRunMode {
+    DryRun,
+    Execute,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StoredRunConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_pattern: Option<String>,
+    pub merge_if_blocked: bool,
+    pub merge_if_checks_skipped: bool,
+    pub merge_type: StoredMergeType,
+    pub sort_by: StoredSortBy,
+    pub sort_direction: StoredSortDirection,
+    pub flags: StoredRunFlags,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoredMergeType {
+    Merge,
+    Squash,
+    Rebase,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoredSortBy {
+    Created,
+    Updated,
+    Popularity,
+    LongRunning,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoredSortDirection {
+    Asc,
+    Desc,
+}
+
+impl From<&MergeType> for StoredMergeType {
+    fn from(value: &MergeType) -> Self {
+        match value {
+            MergeType::Merge => StoredMergeType::Merge,
+            MergeType::Squash => StoredMergeType::Squash,
+            MergeType::Rebase => StoredMergeType::Rebase,
+        }
+    }
+}
+
+impl From<&SortBy> for StoredSortBy {
+    fn from(value: &SortBy) -> Self {
+        match value {
+            SortBy::Created => StoredSortBy::Created,
+            SortBy::Updated => StoredSortBy::Updated,
+            SortBy::Popularity => StoredSortBy::Popularity,
+            SortBy::LongRunning => StoredSortBy::LongRunning,
+        }
+    }
+}
+
+impl From<&SortDirection> for StoredSortDirection {
+    fn from(value: &SortDirection) -> Self {
+        match value {
+            SortDirection::Ascending => StoredSortDirection::Asc,
+            SortDirection::Descending => StoredSortDirection::Desc,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StoredRunFlags {
+    pub show_repos_with_no_prs: bool,
+    pub show_prs_from_untrusted_authors: bool,
+    pub show_prs_with_unmatched_head: bool,
+    pub skip_disqualifications_in_summary: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StoredRepoRecord {
+    pub repo: String,
+    pub owner: String,
+    pub name: String,
+    pub status: StoredRepoStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub prs: Vec<StoredPrRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoredRepoStatus {
+    Finished,
+    Errored,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StoredPrRecord {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+    pub status: StoredPrStatus,
+    pub qualifications: Vec<StoredQualification>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disqualification: Option<StoredDisqualification>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub merged: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoredPrStatus {
+    Qualified,
+    Disqualified,
+    Errored,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum StoredQualification {
+    Head { value: String },
+    Author { value: String },
+    Check { name: String, conclusion: String },
+    State { value: String },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum StoredDisqualification {
+    Head {
+        value: String,
+    },
+    Author {
+        value: Option<String>,
+    },
+    Check {
+        name: String,
+        conclusion: Option<String>,
+    },
+    State {
+        value: Option<String>,
+    },
+}

--- a/src/report/assets/templates/index.html
+++ b/src/report/assets/templates/index.html
@@ -1,92 +1,547 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="color-scheme" content="dark">
-        <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✅</text></svg>">
-        <title>{{ title }}</title>
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
-        <style>
-            body {
-                font-family: "Open Sans", sans-serif;
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="dark light">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✅</text></svg>">
+    <title>{{ title }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #282828;
+            --surface: #3c3836;
+            --row-hover: #504945;
+            --text: #ebdbb2;
+            --text-dim: #b8aa92;
+            --text-muted: #7a6f66;
+            --border: #504945;
+            --border-strong: #665c54;
+            --green: #b8bb26;
+            --green-dim: rgba(184, 187, 38, 0.07);
+            --amber: #fabd2f;
+            --amber-dim: rgba(250, 189, 47, 0.08);
+            --red: #fb4934;
+            --red-dim: rgba(251, 73, 52, 0.07);
+            --accent: #83a598;
+            --accent-hover: #d3869b;
+            --header-bg: rgba(255, 255, 255, 0.03);
+        }
+
+        @media (prefers-color-scheme: light) {
+            :root {
+                --bg: #f4efe6;
+                --surface: #fbf7ef;
+                --row-hover: #efe6d7;
+                --text: #2f241d;
+                --text-dim: #5f5145;
+                --text-muted: #7b6b5e;
+                --border: #d5c4ab;
+                --border-strong: #bca789;
+                --green: #6b7d17;
+                --green-dim: rgba(107, 125, 23, 0.08);
+                --amber: #af6b00;
+                --amber-dim: rgba(175, 107, 0, 0.09);
+                --red: #b53a2d;
+                --red-dim: rgba(181, 58, 45, 0.08);
+                --accent: #326a74;
+                --accent-hover: #b16286;
+                --header-bg: rgba(47, 36, 29, 0.045);
             }
-            .run-output {
-                font-family: "Fira Mono", monospace;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Open Sans", sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.55;
+            font-size: 0.875rem;
+            -webkit-font-smoothing: antialiased;
+            overflow-y: scroll;
+        }
+
+        a { color: inherit; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border-strong) var(--surface);
+        }
+        *::-webkit-scrollbar { width: 6px; height: 6px; }
+        *::-webkit-scrollbar-track { background: var(--surface); }
+        *::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 3px; }
+
+        details > summary { list-style: none; }
+        details > summary::-webkit-details-marker { display: none; }
+
+        .page {
+            max-width: clamp(1400px, 80vw, 2000px);
+            margin: 0 auto;
+            padding: 2rem 2.25rem 3.5rem;
+        }
+
+        @media (max-width: 640px) {
+            .page {
+                max-width: 100%;
+                padding: 1.25rem 1rem 2.5rem;
             }
-            * {
-                scrollbar-width: thin;
-                scrollbar-color: #928374 #2e2c2c;
+
+            .page-header {
+                gap: 0.85rem 0.9rem;
+                margin-bottom: 1.5rem;
+                align-items: flex-start;
             }
-            *::-webkit-scrollbar {
-                width: 8px;
-                height: 8px;
+
+            .page-title {
+                font-size: 1.625rem;
             }
-            *::-webkit-scrollbar-track {
-                background: #282828;
+
+            .page-meta {
+                width: 100%;
+                justify-content: space-between;
+                gap: 0.75rem;
+                align-items: center;
             }
-            *::-webkit-scrollbar-thumb {
-                background: #a594f940;
-                border-radius: 4px;
+
+            .col-status { width: 92px; }
+            .col-repo { width: 116px; }
+            .col-num { width: 36px; }
+            .col-remarks { width: 42%; }
+
+            .board {
+                margin-bottom: 1.25rem;
             }
-        </style>
-    </head>
-    <body class="bg-[#282828] overflow-y-scroll">
-        <div class="w-4/5 max-sm:w-full max-sm:px-4 mx-auto min-h-screen pt-8">
-            <div class="flex flex-col gap-2">
-                <h1 class="text-[#fbf1c7] text-3xl font-semibold">{{ title }}</h1>
-                <p class="text-[#928374] italic">Generated at {{ timestamp }}</p>
-            </div>
-            {%- if runs | length > 0 %}
-            <div class="overflow-x-auto pt-4">
-                <div class="flex gap-4 items-center pb-2">
-                    <button class="bg-[#83a598] text-[#282828] font-semibold text-xs p-2 hover:bg-[#fabd2f] cursor-pointer" onclick="toggleAllDetails()">
-                    Toggle All
-                    </button>
+
+            .board-header {
+                gap: 0.5rem 0.65rem;
+                padding: 0.7rem 0.75rem;
+            }
+
+            .board-stats {
+                width: 100%;
+                margin-left: 0;
+                padding-top: 0.2rem;
+                gap: 0.75rem;
+            }
+
+            .board-config {
+                padding: 0.55rem 0.75rem;
+                line-height: 1.6;
+            }
+
+            .board-table th,
+            .board-table td {
+                padding-top: 0.55rem;
+                padding-bottom: 0.55rem;
+            }
+
+            .board-table th:nth-child(-n+3),
+            .board-table td:nth-child(-n+3) {
+                padding-left: 0.7rem;
+                padding-right: 0.7rem;
+            }
+
+            .board-table td:nth-child(4),
+            .board-table td:nth-child(5) {
+                min-width: 170px;
+            }
+        }
+
+        .page-header {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 0.85rem 1.25rem;
+            margin-bottom: 2rem;
+        }
+
+        .page-title {
+            font-size: 1.75rem;
+            font-weight: 700;
+            letter-spacing: -0.015em;
+            line-height: 1.15;
+        }
+
+        .page-meta {
+            display: flex;
+            align-items: center;
+            gap: 0.9rem;
+        }
+
+        .page-timestamp {
+            font-size: 0.9375rem;
+            font-style: italic;
+            color: var(--text-dim);
+            line-height: 1.3;
+        }
+
+        .toggle-btn {
+            font-family: inherit;
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--bg);
+            background: var(--accent);
+            border: none;
+            padding: 0.38rem 0.7rem;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .toggle-btn:hover {
+            background: var(--accent-hover);
+        }
+
+        @media (prefers-color-scheme: light) {
+            .toggle-btn {
+                color: var(--surface);
+            }
+        }
+
+        .board {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            margin-bottom: 1.75rem;
+        }
+
+        .board:last-child {
+            margin-bottom: 0;
+        }
+
+        .board-header {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.55rem 0.85rem;
+            padding: 0.9rem 1rem;
+            border-bottom: 1px solid var(--border);
+            cursor: pointer;
+            transition: background 0.1s;
+        }
+        .board-header:hover { background: var(--row-hover); }
+
+        .toggle-icon {
+            font-size: 0.625rem;
+            color: var(--text-muted);
+            transition: transform 0.15s ease;
+            display: inline-block;
+        }
+        details[open] .toggle-icon { transform: rotate(90deg); }
+
+        .run-label {
+            font-size: 0.9375rem;
+            font-weight: 700;
+        }
+
+        .mode-badge {
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            padding: 0.14rem 0.42rem;
+            border: 1px solid;
+        }
+        .mode-execute { color: var(--green); border-color: var(--green); }
+        .mode-other { color: var(--text-dim); border-color: var(--text-muted); }
+
+        .run-took {
+            font-size: 0.8125rem;
+            color: var(--text-dim);
+        }
+
+        .board-stats {
+            display: flex;
+            align-items: center;
+            gap: 0.7rem;
+            margin-left: auto;
+        }
+
+        .stat {
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+        }
+        .stat-blue { color: var(--accent); }
+        .stat-green { color: var(--green); }
+        .stat-amber { color: var(--amber); }
+        .stat-red { color: var(--red); }
+
+        .board-config {
+            font-size: 0.75rem;
+            color: var(--text-dim);
+            padding: 0.6rem 1rem;
+            border-bottom: 1px solid var(--border);
+            background: var(--header-bg);
+            line-height: 1.55;
+        }
+
+        .board-error-banner {
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: var(--red);
+            padding: 0.6rem 1rem;
+            background: var(--red-dim);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .board-table-wrap { overflow-x: auto; }
+
+        .board-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-family: "Fira Mono", monospace;
+            font-size: 0.8125rem;
+        }
+
+        .col-status { width: 130px; }
+        .col-repo { width: 170px; }
+        .col-num { width: 50px; }
+        .col-remarks { width: 34%; }
+
+        .board-table th {
+            text-align: left;
+            font-size: 0.6875rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--text-dim);
+            padding: 0.6rem 1rem;
+            background: var(--header-bg);
+            border-bottom: 2px solid var(--border-strong);
+            white-space: nowrap;
+        }
+
+        .board-table td {
+            padding: 0.6rem 1rem;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+            white-space: nowrap;
+        }
+
+        .board-table td.cell-wrap {
+            white-space: normal;
+            word-break: break-word;
+        }
+
+        .board-table tbody tr { transition: background 0.08s; }
+
+        .row-dq { background: transparent; }
+        .row-err { background: transparent; }
+        .row-ok { background: transparent; }
+
+        .board-table tbody tr:hover { background: var(--row-hover); }
+
+        tr[data-url] { cursor: pointer; }
+
+        .badge {
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+        }
+        .badge-dq { color: var(--amber); }
+        .badge-err { color: var(--red); }
+        .badge-ok { color: var(--green); }
+        .badge-merged { color: var(--green); }
+
+        .cell-repo { color: var(--text-dim); }
+        .cell-num { color: var(--text-dim); }
+        .cell-dim { color: var(--text-dim); font-style: italic; }
+
+        .remarks { font-size: 0.8125rem; }
+        .remarks-dq { color: var(--amber); }
+        .remarks-err { color: var(--red); }
+        .remarks-ok { color: var(--text-dim); }
+
+        .empty-state {
+            padding: 3rem 1rem;
+            text-align: center;
+            color: var(--text-dim);
+        }
+
+        .page-footer {
+            margin-top: 2.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid var(--border);
+            font-size: 0.9375rem;
+            font-style: italic;
+            color: var(--text-dim);
+        }
+        .page-footer a { font-weight: 600; }
+
+        .scroll-top {
+            display: none;
+            position: fixed;
+            bottom: 1rem;
+            left: 1rem;
+            z-index: 50;
+            background: var(--text-dim);
+            color: var(--bg);
+            border: 0;
+            width: 2.25rem;
+            height: 2.25rem;
+            font-family: inherit;
+            font-weight: 700;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .scroll-top:hover { background: var(--accent-hover); }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <header>
+            <div class="page-header">
+                <h1 class="page-title">{{ title }}</h1>
+                <div class="page-meta">
+                    <span class="page-timestamp">{{ timestamp | date(format="%Y-%m-%d %H:%M UTC") }}</span>
+                    <button class="toggle-btn" onclick="toggleAllRuns()">toggle all</button>
                 </div>
-                {%- for run in runs %}
-                <div class="my-2 overflow-x-auto">
-                    <details>
-                        <summary class="text-[#83a598] cursor-pointer max-sm:text-sm mb-2">
-                            {{ run.label }}
-                        </summary>
-                        <div class="max-sm:p-2 p-4 bg-[#2e2c2c] run-output max-sm:text-xs text-sm">
-                            <pre class="run-output text-[#b8bb26] overflow-x-auto max-sm:text-xs text-sm">{{ run.contents }}</pre>
-                        </div>
-                    </details>
-                </div>
-                {%- endfor %}
             </div>
-            {%- else %}
-            <p class="text-[#928374] mt-4">No runs found yet.</p>
-            {%- endif %}
-            <p class="text-[#928374] italic my-10 pt-2 border-t-2 border-[#92837433]">Built using <a class="font-bold" href="https://github.com/dhth/mrj" target="_blank" rel="noopener noreferrer">mrj</a></p>
-        </div>
-        <button id="scrollToTop" onclick="window.scrollTo({top: 0, behavior: 'smooth'});"
-            class="hidden fixed bottom-4 left-4 z-50 bg-[#928374] text-[#282828] px-4 py-2 rounded-full shadow-lg hover:bg-[#d3869b] font-bold transition">
-        ↑
-        </button>
-        <script>
-            const scrollToTopButton = document.getElementById("scrollToTop");
-            let allDetailsOpen = false;
-            
-            function toggleAllDetails() {
-                allDetailsOpen = !allDetailsOpen;
-                document.querySelectorAll("details").forEach((detail) => {
-                    detail.open = allDetailsOpen;
-                });
-            }
-            
-            window.addEventListener("scroll", function () {
-                if (window.scrollY > 100) {
-                    scrollToTopButton.classList.remove("hidden");
-                } else {
-                    scrollToTopButton.classList.add("hidden");
-                }
+        </header>
+
+        {%- if runs | length > 0 %}
+        <main>
+            {%- for run in runs %}
+            <details {% if loop.first %}open{% endif %} data-run-details class="board">
+                <summary class="board-header">
+                    <span class="toggle-icon">&#9654;</span>
+                    <span class="run-label">{{ run.finished_at | date(format="%a %b %d · %H:%M UTC") }}</span>
+                    {%- if run.mode == "execute" %}
+                    <span class="mode-badge mode-execute">{{ run.mode }}</span>
+                    {%- else %}
+                    <span class="mode-badge mode-other">{{ run.mode }}</span>
+                    {%- endif %}
+                    <div class="board-stats">
+                        <span class="stat stat-green">{{ run.summary.num_merged }} merged</span>
+                        <span class="stat stat-amber">{{ run.summary.num_disqualifications }} disqualified</span>
+                        {%- if run.summary.num_errors > 0 %}
+                        <span class="stat stat-red">{{ run.summary.num_errors }} errored</span>
+                        {%- endif %}
+                    </div>
+                </summary>
+
+                <div class="board-config">
+                    base={{ run.config.base_branch | default(value="any") }}
+                    &middot; head={{ run.config.head_pattern | default(value="not set") }}
+                    &middot; merge-type={{ run.config.merge_type }}
+                    &middot; sort={{ run.config.sort_by }}/{{ run.config.sort_direction }}
+                    &middot; merge-if-blocked={{ run.config.merge_if_blocked }}
+                    &middot; merge-if-checks-skipped={{ run.config.merge_if_checks_skipped }}
+                </div>
+
+                <div class="board-table-wrap">
+                    <table class="board-table">
+                        <thead>
+                            <tr>
+                                <th class="col-status">Status</th>
+                                <th class="col-repo">Repo</th>
+                                <th class="col-num">#</th>
+                                <th>Title</th>
+                                <th class="col-remarks">Remarks</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {%- for repo in run.repos %}
+                            {%- if not repo.error %}
+                            {%- for pr in repo.prs %}
+                            {%- if pr.status == "disqualified" %}
+                            <tr class="row-dq" data-url="{{ pr.url }}">
+                                <td><span class="badge badge-dq">DISQUALIFIED</span></td>
+                                <td class="cell-repo">{{ repo.repo }}</td>
+                                <td class="cell-num">{{ pr.number }}</td>
+                                <td class="cell-wrap">{{ pr.title }}</td>
+                                <td class="cell-wrap remarks remarks-dq">{%- if pr.disqualification %}&#x2717; {{ pr.disqualification.kind }} &middot; {% if pr.disqualification.kind == "check" %}{{ pr.disqualification.name }}{%- if pr.disqualification.conclusion %}: {{ pr.disqualification.conclusion }}{%- endif %}{% else %}{{ pr.disqualification.value | default(value="unknown") }}{% endif %}{%- endif %}</td>
+                            </tr>
+                            {%- endif %}
+                            {%- endfor %}
+                            {%- endif %}
+                            {%- endfor %}
+                            {%- for repo in run.repos %}
+                            {%- if repo.error %}
+                            <tr class="row-err">
+                                <td><span class="badge badge-err">ERROR</span></td>
+                                <td class="cell-repo">{{ repo.repo }}</td>
+                                <td class="cell-num">&mdash;</td>
+                                <td class="cell-dim cell-wrap">&mdash;</td>
+                                <td class="cell-wrap remarks remarks-err">&#x26A0; {{ repo.error }}</td>
+                            </tr>
+                            {%- else %}
+                            {%- for pr in repo.prs %}
+                            {%- if pr.status != "qualified" and pr.status != "disqualified" %}
+                            <tr class="row-err" data-url="{{ pr.url }}">
+                                <td><span class="badge badge-err">ERRORED</span></td>
+                                <td class="cell-repo">{{ repo.repo }}</td>
+                                <td class="cell-num">{{ pr.number }}</td>
+                                <td class="cell-wrap">{{ pr.title }}</td>
+                                <td class="cell-wrap remarks remarks-err">{%- if pr.error %}{{ pr.error }}{%- endif %}</td>
+                            </tr>
+                            {%- endif %}
+                            {%- endfor %}
+                            {%- endif %}
+                            {%- endfor %}
+                            {%- for repo in run.repos %}
+                            {%- if not repo.error %}
+                            {%- for pr in repo.prs %}
+                            {%- if pr.status == "qualified" %}
+                            <tr class="row-ok" data-url="{{ pr.url }}">
+                                {%- if pr.merged %}
+                                <td><span class="badge badge-merged">MERGED</span></td>
+                                {%- else %}
+                                <td><span class="badge badge-ok">QUALIFIED</span></td>
+                                {%- endif %}
+                                <td class="cell-repo">{{ repo.repo }}</td>
+                                <td class="cell-num">{{ pr.number }}</td>
+                                <td class="cell-wrap">{{ pr.title }}</td>
+                                <td class="cell-wrap remarks remarks-ok">{%- if pr.merged %}&#10003; merged{%- endif %}</td>
+                            </tr>
+                            {%- endif %}
+                            {%- endfor %}
+                            {%- endif %}
+                            {%- endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </details>
+            {%- endfor %}
+        </main>
+        {%- else %}
+        <div class="empty-state">No runs found yet.</div>
+        {%- endif %}
+
+        <footer class="page-footer">
+            Built using <a href="https://github.com/dhth/mrj" target="_blank" rel="noopener noreferrer">mrj</a>
+        </footer>
+    </div>
+
+    <button id="scrollToTop" class="scroll-top" onclick="window.scrollTo({top: 0, behavior: 'smooth'});">&#8593;</button>
+
+    <script>
+        let allRunsOpen = true;
+        const scrollToTopButton = document.getElementById("scrollToTop");
+
+        function toggleAllRuns() {
+            allRunsOpen = !allRunsOpen;
+            document.querySelectorAll("[data-run-details]").forEach(function(d) {
+                d.open = allRunsOpen;
             });
-        </script>
-    </body>
+        }
+
+        document.querySelectorAll("[data-url]").forEach(function(row) {
+            row.addEventListener("click", function(e) {
+                if (e.target.closest("a")) return;
+                window.open(this.dataset.url, "_blank");
+            });
+        });
+
+        window.addEventListener("scroll", function() {
+            scrollToTopButton.style.display = window.scrollY > 100 ? "block" : "none";
+        });
+    </script>
+</body>
 </html>

--- a/src/report/assets/templates/index.html
+++ b/src/report/assets/templates/index.html
@@ -456,7 +456,7 @@
                                 <td class="cell-repo">{{ repo.repo }}</td>
                                 <td class="cell-num">{{ pr.number }}</td>
                                 <td class="cell-wrap">{{ pr.title }}</td>
-                                <td class="cell-wrap remarks remarks-dq">{%- if pr.disqualification %}&#x2717; {{ pr.disqualification.kind }} &middot; {% if pr.disqualification.kind == "check" %}{{ pr.disqualification.name }}{%- if pr.disqualification.conclusion %}: {{ pr.disqualification.conclusion }}{%- endif %}{% else %}{{ pr.disqualification.value | default(value="unknown") }}{% endif %}{%- endif %}</td>
+                                <td class="cell-wrap remarks remarks-dq">{%- if pr.disqualification %}&#x2717; {{ pr.disqualification.kind }} &middot; {% if pr.disqualification.kind == "check" %}{{ pr.disqualification.name }}{%- if pr.disqualification.conclusion %}: {{ pr.disqualification.conclusion }}{%- endif %}{% elif pr.disqualification.value %}{{ pr.disqualification.value }}{% else %}unknown{% endif %}{%- endif %}</td>
                             </tr>
                             {%- endif %}
                             {%- endfor %}

--- a/src/report/assets/templates/index.html
+++ b/src/report/assets/templates/index.html
@@ -535,7 +535,7 @@
         document.querySelectorAll("[data-url]").forEach(function(row) {
             row.addEventListener("click", function(e) {
                 if (e.target.closest("a")) return;
-                window.open(this.dataset.url, "_blank");
+                window.open(this.dataset.url, "_blank", "noopener,noreferrer");
             });
         });
 

--- a/src/report/data.rs
+++ b/src/report/data.rs
@@ -1,7 +1,0 @@
-use serde::Serialize;
-
-#[derive(Serialize)]
-pub(super) struct RunData {
-    pub(super) label: String,
-    pub(super) contents: String,
-}

--- a/src/report/generate.rs
+++ b/src/report/generate.rs
@@ -24,14 +24,14 @@ pub fn generate_report(config: &ReportConfig) -> anyhow::Result<()> {
     let run_number = last_run_number + 1;
     let now = Utc::now();
     let date = now.format("%a-%b-%d").to_string().to_lowercase();
-    let new_run_file = runs_dir.join(format!("run-{run_number}--{date}.txt"));
+    let new_run_file = runs_dir.join(format!("run-{run_number}--{date}.json"));
 
     std::fs::copy(&config.output_path, new_run_file)
         .context("couldn't copy latest run to mrj's \"runs\" directory")?;
 
     #[allow(clippy::expect_used)]
     let file_regex =
-        Regex::new(r"^run-(\d+)[^\.]*\.txt$").expect("regex for run files should've been built");
+        Regex::new(r"^run-(\d+)[^\.]*\.json$").expect("regex for run files should've been built");
 
     super::io::keep_last_n_outputs(&runs_dir, config.num_runs, &file_regex)?;
 

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -1,13 +1,21 @@
-use super::data::RunData;
 use anyhow::Context;
 use chrono::{DateTime, Utc};
+use serde::Serialize;
 use tera::{Context as TeraContext, Tera};
 
+use crate::persistence::schema::StoredRunData;
+
 const BUILTIN_TEMPLATE: &str = include_str!("./assets/templates/index.html");
-const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%SZ";
+
+#[derive(Serialize)]
+struct ReportContext<'a> {
+    title: &'a str,
+    timestamp: DateTime<Utc>,
+    runs: &'a [StoredRunData],
+}
 
 pub(super) fn render_report(
-    runs: &[RunData],
+    runs: &[StoredRunData],
     reference_time: DateTime<Utc>,
     custom_template: Option<&str>,
     title: &str,
@@ -22,13 +30,12 @@ pub(super) fn render_report(
             .context("failed to parse built-in HTML template")?,
     }
 
-    let mut tera_ctx = TeraContext::new();
-    tera_ctx.insert("title", title);
-    tera_ctx.insert(
-        "timestamp",
-        &reference_time.format(TIMESTAMP_FORMAT).to_string(),
-    );
-    tera_ctx.insert("runs", runs);
+    let tera_ctx = TeraContext::from_serialize(ReportContext {
+        title,
+        timestamp: reference_time,
+        runs,
+    })
+    .context("failed to build report context")?;
 
     let page_contents = tera
         .render("template.html", &tera_ctx)
@@ -40,27 +47,24 @@ pub(super) fn render_report(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persistence::schema::{
+        StoredDisqualification, StoredMergeType, StoredPrRecord, StoredPrStatus,
+        StoredQualification, StoredRepoRecord, StoredRepoStatus, StoredRunConfig, StoredRunData,
+        StoredRunFlags, StoredRunMode, StoredRunSummary, StoredSortBy, StoredSortDirection,
+    };
     use chrono::TimeZone;
     use insta::assert_snapshot;
 
-    const CONTENT1: &str = include_str!("testdata/rundata/runs/run-576--sat-nov-01.txt");
-    const CONTENT2: &str = include_str!("testdata/rundata/runs/run-577--sun-nov-02.txt");
     const CUSTOM_TEMPLATE: &str = include_str!("testdata/custom_template.html");
 
     #[test]
     fn render_report_works_for_builtin_template() -> anyhow::Result<()> {
         // GIVEN
-        let runs = vec![
-            RunData {
-                label: "run-576 (sat-nov-01)".into(),
-                contents: CONTENT1.trim().to_string(),
-            },
-            RunData {
-                label: "run-577 (sun-nov-02)".into(),
-                contents: CONTENT2.trim().to_string(),
-            },
-        ];
-        let now = Utc.with_ymd_and_hms(2025, 1, 16, 12, 0, 0).unwrap();
+        let runs = sample_runs();
+        let now = Utc
+            .with_ymd_and_hms(2025, 1, 16, 12, 0, 0)
+            .single()
+            .unwrap();
 
         // WHEN
         let result = render_report(runs.as_slice(), now, None, "mrj runs")?;
@@ -74,17 +78,11 @@ mod tests {
     #[test]
     fn render_report_works_for_custom_template() -> anyhow::Result<()> {
         // GIVEN
-        let runs = vec![
-            RunData {
-                label: "run-576 (sat-nov-01)".into(),
-                contents: CONTENT1.trim().to_string(),
-            },
-            RunData {
-                label: "run-577 (sun-nov-02)".into(),
-                contents: CONTENT2.trim().to_string(),
-            },
-        ];
-        let now = Utc.with_ymd_and_hms(2025, 1, 16, 12, 0, 0).unwrap();
+        let runs = sample_runs();
+        let now = Utc
+            .with_ymd_and_hms(2025, 1, 16, 12, 0, 0)
+            .single()
+            .unwrap();
 
         // WHEN
         let result = render_report(
@@ -98,5 +96,204 @@ mod tests {
         assert_snapshot!(result);
 
         Ok(())
+    }
+
+    fn sample_runs() -> Vec<StoredRunData> {
+        vec![
+            StoredRunData {
+                started_at: Utc
+                    .with_ymd_and_hms(2025, 11, 2, 23, 31, 11)
+                    .single()
+                    .unwrap(),
+                finished_at: Utc
+                    .with_ymd_and_hms(2025, 11, 2, 23, 31, 47)
+                    .single()
+                    .unwrap(),
+                took_ms: 36_000,
+                mode: StoredRunMode::DryRun,
+                config: StoredRunConfig {
+                    base_branch: Some("main".into()),
+                    head_pattern: Some("(dependabot|update)".into()),
+                    merge_if_blocked: false,
+                    merge_if_checks_skipped: true,
+                    merge_type: StoredMergeType::Squash,
+                    sort_by: StoredSortBy::Created,
+                    sort_direction: StoredSortDirection::Asc,
+                    flags: StoredRunFlags {
+                        show_repos_with_no_prs: false,
+                        show_prs_from_untrusted_authors: false,
+                        show_prs_with_unmatched_head: false,
+                        skip_disqualifications_in_summary: false,
+                    },
+                },
+                summary: StoredRunSummary {
+                    num_disqualifications: 1,
+                    num_errors: 2,
+                    num_merged: 0,
+                },
+                repos: vec![
+                    StoredRepoRecord {
+                        repo: "dhth/mrj".into(),
+                        owner: "dhth".into(),
+                        name: "mrj".into(),
+                        status: StoredRepoStatus::Finished,
+                        error: None,
+                        prs: vec![
+                            StoredPrRecord {
+                                number: 12,
+                                title: "build: bump clap from 4.5.39 to 4.5.40".into(),
+                                url: "https://github.com/dhth/mrj/pull/12".into(),
+                                created_at: Some(
+                                    Utc.with_ymd_and_hms(2025, 11, 2, 23, 0, 0)
+                                        .single()
+                                        .unwrap(),
+                                ),
+                                updated_at: Some(
+                                    Utc.with_ymd_and_hms(2025, 11, 2, 23, 10, 0)
+                                        .single()
+                                        .unwrap(),
+                                ),
+                                status: StoredPrStatus::Disqualified,
+                                qualifications: vec![StoredQualification::Head {
+                                    value: "dependabot/cargo/clap-4.5.40".into(),
+                                }],
+                                disqualification: Some(StoredDisqualification::Author {
+                                    value: Some("untrusted-bot".into()),
+                                }),
+                                error: None,
+                                merged: false,
+                            },
+                            StoredPrRecord {
+                                number: 13,
+                                title: "build: bump tera from 1.19.0 to 1.20.1".into(),
+                                url: "https://github.com/dhth/mrj/pull/13".into(),
+                                created_at: Some(
+                                    Utc.with_ymd_and_hms(2025, 11, 2, 23, 5, 0)
+                                        .single()
+                                        .unwrap(),
+                                ),
+                                updated_at: Some(
+                                    Utc.with_ymd_and_hms(2025, 11, 2, 23, 12, 0)
+                                        .single()
+                                        .unwrap(),
+                                ),
+                                status: StoredPrStatus::Qualified,
+                                qualifications: vec![
+                                    StoredQualification::Head {
+                                        value: "dependabot/cargo/tera-1.20.1".into(),
+                                    },
+                                    StoredQualification::Author {
+                                        value: "dependabot[bot]".into(),
+                                    },
+                                    StoredQualification::Check {
+                                        name: "test".into(),
+                                        conclusion: "success".into(),
+                                    },
+                                ],
+                                disqualification: None,
+                                error: None,
+                                merged: false,
+                            },
+                            StoredPrRecord {
+                                number: 14,
+                                title: "build: bump regex from 1.12.2 to 1.12.3".into(),
+                                url: "https://github.com/dhth/mrj/pull/14".into(),
+                                created_at: Some(
+                                    Utc.with_ymd_and_hms(2025, 11, 2, 23, 8, 0)
+                                        .single()
+                                        .unwrap(),
+                                ),
+                                updated_at: Some(
+                                    Utc.with_ymd_and_hms(2025, 11, 2, 23, 15, 0)
+                                        .single()
+                                        .unwrap(),
+                                ),
+                                status: StoredPrStatus::Errored,
+                                qualifications: vec![StoredQualification::Head {
+                                    value: "dependabot/cargo/regex-1.12.3".into(),
+                                }],
+                                disqualification: None,
+                                error: Some("GitHub API returned a transient error".into()),
+                                merged: false,
+                            },
+                        ],
+                    },
+                    StoredRepoRecord {
+                        repo: "dhth/bmm".into(),
+                        owner: "dhth".into(),
+                        name: "bmm".into(),
+                        status: StoredRepoStatus::Errored,
+                        error: Some("couldn't fetch open PRs for repo".into()),
+                        prs: vec![],
+                    },
+                ],
+            },
+            StoredRunData {
+                started_at: Utc
+                    .with_ymd_and_hms(2025, 11, 1, 22, 32, 41)
+                    .single()
+                    .unwrap(),
+                finished_at: Utc
+                    .with_ymd_and_hms(2025, 11, 1, 22, 33, 11)
+                    .single()
+                    .unwrap(),
+                took_ms: 30_000,
+                mode: StoredRunMode::Execute,
+                config: StoredRunConfig {
+                    base_branch: Some("main".into()),
+                    head_pattern: Some("dependabot".into()),
+                    merge_if_blocked: false,
+                    merge_if_checks_skipped: false,
+                    merge_type: StoredMergeType::Squash,
+                    sort_by: StoredSortBy::Updated,
+                    sort_direction: StoredSortDirection::Desc,
+                    flags: StoredRunFlags {
+                        show_repos_with_no_prs: true,
+                        show_prs_from_untrusted_authors: false,
+                        show_prs_with_unmatched_head: false,
+                        skip_disqualifications_in_summary: false,
+                    },
+                },
+                summary: StoredRunSummary {
+                    num_disqualifications: 0,
+                    num_errors: 0,
+                    num_merged: 1,
+                },
+                repos: vec![StoredRepoRecord {
+                    repo: "dhth/mrj".into(),
+                    owner: "dhth".into(),
+                    name: "mrj".into(),
+                    status: StoredRepoStatus::Finished,
+                    error: None,
+                    prs: vec![StoredPrRecord {
+                        number: 11,
+                        title: "build: bump octocrab from 0.49.6 to 0.49.7".into(),
+                        url: "https://github.com/dhth/mrj/pull/11".into(),
+                        created_at: Some(
+                            Utc.with_ymd_and_hms(2025, 11, 1, 22, 20, 0)
+                                .single()
+                                .unwrap(),
+                        ),
+                        updated_at: Some(
+                            Utc.with_ymd_and_hms(2025, 11, 1, 22, 28, 0)
+                                .single()
+                                .unwrap(),
+                        ),
+                        status: StoredPrStatus::Qualified,
+                        qualifications: vec![
+                            StoredQualification::Head {
+                                value: "dependabot/cargo/octocrab-0.49.7".into(),
+                            },
+                            StoredQualification::Author {
+                                value: "dependabot[bot]".into(),
+                            },
+                        ],
+                        disqualification: None,
+                        error: None,
+                        merged: true,
+                    }],
+                }],
+            },
+        ]
     }
 }

--- a/src/report/io.rs
+++ b/src/report/io.rs
@@ -1,4 +1,4 @@
-use super::data::RunData;
+use crate::persistence::schema::{StoredRunData, StoredRunEnvelope};
 use anyhow::Context;
 use regex::Regex;
 use std::cmp::Reverse;
@@ -76,7 +76,10 @@ where
     Ok(())
 }
 
-pub(super) fn gather_run_data<P>(runs_dir: P, file_regex: &Regex) -> anyhow::Result<Vec<RunData>>
+pub(super) fn gather_run_data<P>(
+    runs_dir: P,
+    file_regex: &Regex,
+) -> anyhow::Result<Vec<StoredRunData>>
 where
     P: AsRef<Path>,
 {
@@ -101,28 +104,20 @@ where
     let mut runs = Vec::new();
 
     for (path, _) in entries.iter() {
-        let file_name_os = match path.file_name() {
-            Some(name) => name,
-            None => continue,
-        };
-
-        let file_name = file_name_os.to_string_lossy();
-        let stem = file_name.replace(".txt", "");
-        let (run_id, date_part) = match stem.split_once("--") {
-            Some((r, d)) => (r.to_string(), Some(d.to_string())),
-            None => (stem.to_string(), None),
-        };
-
-        let label = match date_part {
-            Some(d) => format!("{run_id} ({d})"),
-            None => run_id,
-        };
-
         let mut contents = String::new();
         File::open(path)?.read_to_string(&mut contents)?;
-        contents = contents.trim_end().to_string();
+        let persisted_run: StoredRunEnvelope = match serde_json::from_str(&contents) {
+            Ok(persisted_run) => persisted_run,
+            Err(err) => {
+                eprintln!(
+                    "couldn't parse run output from {}: {err}",
+                    path.to_string_lossy()
+                );
+                continue;
+            }
+        };
 
-        runs.push(RunData { label, contents });
+        runs.push(persisted_run.run);
     }
 
     Ok(runs)
@@ -154,7 +149,7 @@ mod tests {
     fn gather_run_data_works_correctly() -> anyhow::Result<()> {
         // GIVEN
         let runs_dir = "src/report/testdata/rundata/runs";
-        let file_regex = Regex::new(r"^run-(\d+)[^\.]*\.txt$")?;
+        let file_regex = Regex::new(r"^run-(\d+)[^\.]*\.json$")?;
 
         // WHEN
         let result = gather_run_data(runs_dir, &file_regex)?;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,4 +1,3 @@
-mod data;
 mod generate;
 mod html;
 mod io;

--- a/src/report/snapshots/mrj__report__html__tests__render_report_works_for_builtin_template.snap
+++ b/src/report/snapshots/mrj__report__html__tests__render_report_works_for_builtin_template.snap
@@ -540,7 +540,7 @@ expression: result
         document.querySelectorAll("[data-url]").forEach(function(row) {
             row.addEventListener("click", function(e) {
                 if (e.target.closest("a")) return;
-                window.open(this.dataset.url, "_blank");
+                window.open(this.dataset.url, "_blank", "noopener,noreferrer");
             });
         });
 

--- a/src/report/snapshots/mrj__report__html__tests__render_report_works_for_builtin_template.snap
+++ b/src/report/snapshots/mrj__report__html__tests__render_report_works_for_builtin_template.snap
@@ -4,101 +4,549 @@ expression: result
 ---
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="color-scheme" content="dark">
-        <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✅</text></svg>">
-        <title>mrj runs</title>
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
-        <style>
-            body {
-                font-family: "Open Sans", sans-serif;
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="dark light">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✅</text></svg>">
+    <title>mrj runs</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #282828;
+            --surface: #3c3836;
+            --row-hover: #504945;
+            --text: #ebdbb2;
+            --text-dim: #b8aa92;
+            --text-muted: #7a6f66;
+            --border: #504945;
+            --border-strong: #665c54;
+            --green: #b8bb26;
+            --green-dim: rgba(184, 187, 38, 0.07);
+            --amber: #fabd2f;
+            --amber-dim: rgba(250, 189, 47, 0.08);
+            --red: #fb4934;
+            --red-dim: rgba(251, 73, 52, 0.07);
+            --accent: #83a598;
+            --accent-hover: #d3869b;
+            --header-bg: rgba(255, 255, 255, 0.03);
+        }
+
+        @media (prefers-color-scheme: light) {
+            :root {
+                --bg: #f4efe6;
+                --surface: #fbf7ef;
+                --row-hover: #efe6d7;
+                --text: #2f241d;
+                --text-dim: #5f5145;
+                --text-muted: #7b6b5e;
+                --border: #d5c4ab;
+                --border-strong: #bca789;
+                --green: #6b7d17;
+                --green-dim: rgba(107, 125, 23, 0.08);
+                --amber: #af6b00;
+                --amber-dim: rgba(175, 107, 0, 0.09);
+                --red: #b53a2d;
+                --red-dim: rgba(181, 58, 45, 0.08);
+                --accent: #326a74;
+                --accent-hover: #b16286;
+                --header-bg: rgba(47, 36, 29, 0.045);
             }
-            .run-output {
-                font-family: "Fira Mono", monospace;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Open Sans", sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.55;
+            font-size: 0.875rem;
+            -webkit-font-smoothing: antialiased;
+            overflow-y: scroll;
+        }
+
+        a { color: inherit; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border-strong) var(--surface);
+        }
+        *::-webkit-scrollbar { width: 6px; height: 6px; }
+        *::-webkit-scrollbar-track { background: var(--surface); }
+        *::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 3px; }
+
+        details > summary { list-style: none; }
+        details > summary::-webkit-details-marker { display: none; }
+
+        .page {
+            max-width: clamp(1400px, 80vw, 2000px);
+            margin: 0 auto;
+            padding: 2rem 2.25rem 3.5rem;
+        }
+
+        @media (max-width: 640px) {
+            .page {
+                max-width: 100%;
+                padding: 1.25rem 1rem 2.5rem;
             }
-            * {
-                scrollbar-width: thin;
-                scrollbar-color: #928374 #2e2c2c;
+
+            .page-header {
+                gap: 0.85rem 0.9rem;
+                margin-bottom: 1.5rem;
+                align-items: flex-start;
             }
-            *::-webkit-scrollbar {
-                width: 8px;
-                height: 8px;
+
+            .page-title {
+                font-size: 1.625rem;
             }
-            *::-webkit-scrollbar-track {
-                background: #282828;
+
+            .page-meta {
+                width: 100%;
+                justify-content: space-between;
+                gap: 0.75rem;
+                align-items: center;
             }
-            *::-webkit-scrollbar-thumb {
-                background: #a594f940;
-                border-radius: 4px;
+
+            .col-status { width: 92px; }
+            .col-repo { width: 116px; }
+            .col-num { width: 36px; }
+            .col-remarks { width: 42%; }
+
+            .board {
+                margin-bottom: 1.25rem;
             }
-        </style>
-    </head>
-    <body class="bg-[#282828] overflow-y-scroll">
-        <div class="w-4/5 max-sm:w-full max-sm:px-4 mx-auto min-h-screen pt-8">
-            <div class="flex flex-col gap-2">
-                <h1 class="text-[#fbf1c7] text-3xl font-semibold">mrj runs</h1>
-                <p class="text-[#928374] italic">Generated at 2025-01-16T12:00:00Z</p>
+
+            .board-header {
+                gap: 0.5rem 0.65rem;
+                padding: 0.7rem 0.75rem;
+            }
+
+            .board-stats {
+                width: 100%;
+                margin-left: 0;
+                padding-top: 0.2rem;
+                gap: 0.75rem;
+            }
+
+            .board-config {
+                padding: 0.55rem 0.75rem;
+                line-height: 1.6;
+            }
+
+            .board-table th,
+            .board-table td {
+                padding-top: 0.55rem;
+                padding-bottom: 0.55rem;
+            }
+
+            .board-table th:nth-child(-n+3),
+            .board-table td:nth-child(-n+3) {
+                padding-left: 0.7rem;
+                padding-right: 0.7rem;
+            }
+
+            .board-table td:nth-child(4),
+            .board-table td:nth-child(5) {
+                min-width: 170px;
+            }
+        }
+
+        .page-header {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 0.85rem 1.25rem;
+            margin-bottom: 2rem;
+        }
+
+        .page-title {
+            font-size: 1.75rem;
+            font-weight: 700;
+            letter-spacing: -0.015em;
+            line-height: 1.15;
+        }
+
+        .page-meta {
+            display: flex;
+            align-items: center;
+            gap: 0.9rem;
+        }
+
+        .page-timestamp {
+            font-size: 0.9375rem;
+            font-style: italic;
+            color: var(--text-dim);
+            line-height: 1.3;
+        }
+
+        .toggle-btn {
+            font-family: inherit;
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--bg);
+            background: var(--accent);
+            border: none;
+            padding: 0.38rem 0.7rem;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .toggle-btn:hover {
+            background: var(--accent-hover);
+        }
+
+        @media (prefers-color-scheme: light) {
+            .toggle-btn {
+                color: var(--surface);
+            }
+        }
+
+        .board {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            margin-bottom: 1.75rem;
+        }
+
+        .board:last-child {
+            margin-bottom: 0;
+        }
+
+        .board-header {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.55rem 0.85rem;
+            padding: 0.9rem 1rem;
+            border-bottom: 1px solid var(--border);
+            cursor: pointer;
+            transition: background 0.1s;
+        }
+        .board-header:hover { background: var(--row-hover); }
+
+        .toggle-icon {
+            font-size: 0.625rem;
+            color: var(--text-muted);
+            transition: transform 0.15s ease;
+            display: inline-block;
+        }
+        details[open] .toggle-icon { transform: rotate(90deg); }
+
+        .run-label {
+            font-size: 0.9375rem;
+            font-weight: 700;
+        }
+
+        .mode-badge {
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            padding: 0.14rem 0.42rem;
+            border: 1px solid;
+        }
+        .mode-execute { color: var(--green); border-color: var(--green); }
+        .mode-other { color: var(--text-dim); border-color: var(--text-muted); }
+
+        .run-took {
+            font-size: 0.8125rem;
+            color: var(--text-dim);
+        }
+
+        .board-stats {
+            display: flex;
+            align-items: center;
+            gap: 0.7rem;
+            margin-left: auto;
+        }
+
+        .stat {
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+        }
+        .stat-blue { color: var(--accent); }
+        .stat-green { color: var(--green); }
+        .stat-amber { color: var(--amber); }
+        .stat-red { color: var(--red); }
+
+        .board-config {
+            font-size: 0.75rem;
+            color: var(--text-dim);
+            padding: 0.6rem 1rem;
+            border-bottom: 1px solid var(--border);
+            background: var(--header-bg);
+            line-height: 1.55;
+        }
+
+        .board-error-banner {
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: var(--red);
+            padding: 0.6rem 1rem;
+            background: var(--red-dim);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .board-table-wrap { overflow-x: auto; }
+
+        .board-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-family: "Fira Mono", monospace;
+            font-size: 0.8125rem;
+        }
+
+        .col-status { width: 130px; }
+        .col-repo { width: 170px; }
+        .col-num { width: 50px; }
+        .col-remarks { width: 34%; }
+
+        .board-table th {
+            text-align: left;
+            font-size: 0.6875rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--text-dim);
+            padding: 0.6rem 1rem;
+            background: var(--header-bg);
+            border-bottom: 2px solid var(--border-strong);
+            white-space: nowrap;
+        }
+
+        .board-table td {
+            padding: 0.6rem 1rem;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+            white-space: nowrap;
+        }
+
+        .board-table td.cell-wrap {
+            white-space: normal;
+            word-break: break-word;
+        }
+
+        .board-table tbody tr { transition: background 0.08s; }
+
+        .row-dq { background: transparent; }
+        .row-err { background: transparent; }
+        .row-ok { background: transparent; }
+
+        .board-table tbody tr:hover { background: var(--row-hover); }
+
+        tr[data-url] { cursor: pointer; }
+
+        .badge {
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+        }
+        .badge-dq { color: var(--amber); }
+        .badge-err { color: var(--red); }
+        .badge-ok { color: var(--green); }
+        .badge-merged { color: var(--green); }
+
+        .cell-repo { color: var(--text-dim); }
+        .cell-num { color: var(--text-dim); }
+        .cell-dim { color: var(--text-dim); font-style: italic; }
+
+        .remarks { font-size: 0.8125rem; }
+        .remarks-dq { color: var(--amber); }
+        .remarks-err { color: var(--red); }
+        .remarks-ok { color: var(--text-dim); }
+
+        .empty-state {
+            padding: 3rem 1rem;
+            text-align: center;
+            color: var(--text-dim);
+        }
+
+        .page-footer {
+            margin-top: 2.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid var(--border);
+            font-size: 0.9375rem;
+            font-style: italic;
+            color: var(--text-dim);
+        }
+        .page-footer a { font-weight: 600; }
+
+        .scroll-top {
+            display: none;
+            position: fixed;
+            bottom: 1rem;
+            left: 1rem;
+            z-index: 50;
+            background: var(--text-dim);
+            color: var(--bg);
+            border: 0;
+            width: 2.25rem;
+            height: 2.25rem;
+            font-family: inherit;
+            font-weight: 700;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .scroll-top:hover { background: var(--accent-hover); }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <header>
+            <div class="page-header">
+                <h1 class="page-title">mrj runs</h1>
+                <div class="page-meta">
+                    <span class="page-timestamp">2025-01-16 12:00 UTC</span>
+                    <button class="toggle-btn" onclick="toggleAllRuns()">toggle all</button>
+                </div>
             </div>
-            <div class="overflow-x-auto pt-4">
-                <div class="flex gap-4 items-center pb-2">
-                    <button class="bg-[#83a598] text-[#282828] font-semibold text-xs p-2 hover:bg-[#fabd2f] cursor-pointer" onclick="toggleAllDetails()">
-                    Toggle All
-                    </button>
+        </header>
+        <main>
+            <details open data-run-details class="board">
+                <summary class="board-header">
+                    <span class="toggle-icon">&#9654;</span>
+                    <span class="run-label">Sun Nov 02 · 23:31 UTC</span>
+                    <span class="mode-badge mode-other">dry-run</span>
+                    <div class="board-stats">
+                        <span class="stat stat-green">0 merged</span>
+                        <span class="stat stat-amber">1 disqualified</span>
+                        <span class="stat stat-red">2 errored</span>
+                    </div>
+                </summary>
+
+                <div class="board-config">
+                    base=main
+                    &middot; head=(dependabot|update)
+                    &middot; merge-type=squash
+                    &middot; sort=created/asc
+                    &middot; merge-if-blocked=false
+                    &middot; merge-if-checks-skipped=true
                 </div>
-                <div class="my-2 overflow-x-auto">
-                    <details>
-                        <summary class="text-[#83a598] cursor-pointer max-sm:text-sm mb-2">
-                            run-576 (sat-nov-01)
-                        </summary>
-                        <div class="max-sm:p-2 p-4 bg-[#2e2c2c] run-output max-sm:text-xs text-sm">
-                            <pre class="run-output text-[#b8bb26] overflow-x-auto max-sm:text-xs text-sm">[INFO] The time right now is 2025-11-01 22:33:11.521555796 UTC
-[INFO] I&#x27;m only looking for PRs where the base branch is &quot;main&quot;
-[INFO] I&#x27;m sorting PRs based on &quot;creation date&quot; in the &quot;ascending&quot; direction</pre>
-                        </div>
-                    </details>
+
+                <div class="board-table-wrap">
+                    <table class="board-table">
+                        <thead>
+                            <tr>
+                                <th class="col-status">Status</th>
+                                <th class="col-repo">Repo</th>
+                                <th class="col-num">#</th>
+                                <th>Title</th>
+                                <th class="col-remarks">Remarks</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="row-dq" data-url="https:&#x2F;&#x2F;github.com&#x2F;dhth&#x2F;mrj&#x2F;pull&#x2F;12">
+                                <td><span class="badge badge-dq">DISQUALIFIED</span></td>
+                                <td class="cell-repo">dhth&#x2F;mrj</td>
+                                <td class="cell-num">12</td>
+                                <td class="cell-wrap">build: bump clap from 4.5.39 to 4.5.40</td>
+                                <td class="cell-wrap remarks remarks-dq">&#x2717; author &middot; untrusted-bot</td>
+                            </tr>
+                            <tr class="row-err" data-url="https:&#x2F;&#x2F;github.com&#x2F;dhth&#x2F;mrj&#x2F;pull&#x2F;14">
+                                <td><span class="badge badge-err">ERRORED</span></td>
+                                <td class="cell-repo">dhth&#x2F;mrj</td>
+                                <td class="cell-num">14</td>
+                                <td class="cell-wrap">build: bump regex from 1.12.2 to 1.12.3</td>
+                                <td class="cell-wrap remarks remarks-err">GitHub API returned a transient error</td>
+                            </tr>
+                            <tr class="row-err">
+                                <td><span class="badge badge-err">ERROR</span></td>
+                                <td class="cell-repo">dhth&#x2F;bmm</td>
+                                <td class="cell-num">&mdash;</td>
+                                <td class="cell-dim cell-wrap">&mdash;</td>
+                                <td class="cell-wrap remarks remarks-err">&#x26A0; couldn&#x27;t fetch open PRs for repo</td>
+                            </tr>
+                            <tr class="row-ok" data-url="https:&#x2F;&#x2F;github.com&#x2F;dhth&#x2F;mrj&#x2F;pull&#x2F;13">
+                                <td><span class="badge badge-ok">QUALIFIED</span></td>
+                                <td class="cell-repo">dhth&#x2F;mrj</td>
+                                <td class="cell-num">13</td>
+                                <td class="cell-wrap">build: bump tera from 1.19.0 to 1.20.1</td>
+                                <td class="cell-wrap remarks remarks-ok"></td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
-                <div class="my-2 overflow-x-auto">
-                    <details>
-                        <summary class="text-[#83a598] cursor-pointer max-sm:text-sm mb-2">
-                            run-577 (sun-nov-02)
-                        </summary>
-                        <div class="max-sm:p-2 p-4 bg-[#2e2c2c] run-output max-sm:text-xs text-sm">
-                            <pre class="run-output text-[#b8bb26] overflow-x-auto max-sm:text-xs text-sm">[INFO] The time right now is 2025-11-01 23:31:47.722303883 UTC
-[INFO] I&#x27;m only looking for PRs where the base branch is &quot;main&quot;
-[INFO] I&#x27;m sorting PRs based on &quot;creation date&quot; in the &quot;ascending&quot; direction</pre>
-                        </div>
-                    </details>
+            </details>
+            <details  data-run-details class="board">
+                <summary class="board-header">
+                    <span class="toggle-icon">&#9654;</span>
+                    <span class="run-label">Sat Nov 01 · 22:33 UTC</span>
+                    <span class="mode-badge mode-execute">execute</span>
+                    <div class="board-stats">
+                        <span class="stat stat-green">1 merged</span>
+                        <span class="stat stat-amber">0 disqualified</span>
+                    </div>
+                </summary>
+
+                <div class="board-config">
+                    base=main
+                    &middot; head=dependabot
+                    &middot; merge-type=squash
+                    &middot; sort=updated/desc
+                    &middot; merge-if-blocked=false
+                    &middot; merge-if-checks-skipped=false
                 </div>
-            </div>
-            <p class="text-[#928374] italic my-10 pt-2 border-t-2 border-[#92837433]">Built using <a class="font-bold" href="https://github.com/dhth/mrj" target="_blank" rel="noopener noreferrer">mrj</a></p>
-        </div>
-        <button id="scrollToTop" onclick="window.scrollTo({top: 0, behavior: 'smooth'});"
-            class="hidden fixed bottom-4 left-4 z-50 bg-[#928374] text-[#282828] px-4 py-2 rounded-full shadow-lg hover:bg-[#d3869b] font-bold transition">
-        ↑
-        </button>
-        <script>
-            const scrollToTopButton = document.getElementById("scrollToTop");
-            let allDetailsOpen = false;
-            
-            function toggleAllDetails() {
-                allDetailsOpen = !allDetailsOpen;
-                document.querySelectorAll("details").forEach((detail) => {
-                    detail.open = allDetailsOpen;
-                });
-            }
-            
-            window.addEventListener("scroll", function () {
-                if (window.scrollY > 100) {
-                    scrollToTopButton.classList.remove("hidden");
-                } else {
-                    scrollToTopButton.classList.add("hidden");
-                }
+
+                <div class="board-table-wrap">
+                    <table class="board-table">
+                        <thead>
+                            <tr>
+                                <th class="col-status">Status</th>
+                                <th class="col-repo">Repo</th>
+                                <th class="col-num">#</th>
+                                <th>Title</th>
+                                <th class="col-remarks">Remarks</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="row-ok" data-url="https:&#x2F;&#x2F;github.com&#x2F;dhth&#x2F;mrj&#x2F;pull&#x2F;11">
+                                <td><span class="badge badge-merged">MERGED</span></td>
+                                <td class="cell-repo">dhth&#x2F;mrj</td>
+                                <td class="cell-num">11</td>
+                                <td class="cell-wrap">build: bump octocrab from 0.49.6 to 0.49.7</td>
+                                <td class="cell-wrap remarks remarks-ok">&#10003; merged</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </details>
+        </main>
+
+        <footer class="page-footer">
+            Built using <a href="https://github.com/dhth/mrj" target="_blank" rel="noopener noreferrer">mrj</a>
+        </footer>
+    </div>
+
+    <button id="scrollToTop" class="scroll-top" onclick="window.scrollTo({top: 0, behavior: 'smooth'});">&#8593;</button>
+
+    <script>
+        let allRunsOpen = true;
+        const scrollToTopButton = document.getElementById("scrollToTop");
+
+        function toggleAllRuns() {
+            allRunsOpen = !allRunsOpen;
+            document.querySelectorAll("[data-run-details]").forEach(function(d) {
+                d.open = allRunsOpen;
             });
-        </script>
-    </body>
+        }
+
+        document.querySelectorAll("[data-url]").forEach(function(row) {
+            row.addEventListener("click", function(e) {
+                if (e.target.closest("a")) return;
+                window.open(this.dataset.url, "_blank");
+            });
+        });
+
+        window.addEventListener("scroll", function() {
+            scrollToTopButton.style.display = window.scrollY > 100 ? "block" : "none";
+        });
+    </script>
+</body>
 </html>

--- a/src/report/snapshots/mrj__report__html__tests__render_report_works_for_custom_template.snap
+++ b/src/report/snapshots/mrj__report__html__tests__render_report_works_for_custom_template.snap
@@ -2,17 +2,35 @@
 source: src/report/html.rs
 expression: result
 ---
-custom template
-Generated at 2025-01-16T12:00:00Z
--> run-576 (sat-nov-01)
----
-[INFO] The time right now is 2025-11-01 22:33:11.521555796 UTC
-[INFO] I&#x27;m only looking for PRs where the base branch is &quot;main&quot;
-[INFO] I&#x27;m sorting PRs based on &quot;creation date&quot; in the &quot;ascending&quot; direction
----
--> run-577 (sun-nov-02)
----
-[INFO] The time right now is 2025-11-01 23:31:47.722303883 UTC
-[INFO] I&#x27;m only looking for PRs where the base branch is &quot;main&quot;
-[INFO] I&#x27;m sorting PRs based on &quot;creation date&quot; in the &quot;ascending&quot; direction
----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>custom template</title>
+</head>
+<body>
+    <h1>custom template</h1>
+    <p>Generated at 2025-01-16T12:00:00Z</p>
+    <section>
+        <h2>2025-11-02</h2>
+        <p>mode=dry-run took=36000</p>
+        <p>
+            summary=0 merged / 1 disqualified / 2 errors
+        </p>
+        <ul>
+            <li>repo=dhth&#x2F;mrj status=finished prs=3</li>
+            <li>repo=dhth&#x2F;bmm status=errored prs=0</li>
+        </ul>
+    </section>
+    <section>
+        <h2>2025-11-01</h2>
+        <p>mode=execute took=30000</p>
+        <p>
+            summary=1 merged / 0 disqualified / 0 errors
+        </p>
+        <ul>
+            <li>repo=dhth&#x2F;mrj status=finished prs=1</li>
+        </ul>
+    </section>
+</body>
+</html>

--- a/src/report/snapshots/mrj__report__io__tests__gather_run_data_works_correctly.snap
+++ b/src/report/snapshots/mrj__report__io__tests__gather_run_data_works_correctly.snap
@@ -2,7 +2,114 @@
 source: src/report/io.rs
 expression: result
 ---
-- label: run-577 (sun-nov-02)
-  contents: "[INFO] The time right now is 2025-11-01 23:31:47.722303883 UTC\n[INFO] I'm only looking for PRs where the base branch is \"main\"\n[INFO] I'm sorting PRs based on \"creation date\" in the \"ascending\" direction"
-- label: run-576 (sat-nov-01)
-  contents: "[INFO] The time right now is 2025-11-01 22:33:11.521555796 UTC\n[INFO] I'm only looking for PRs where the base branch is \"main\"\n[INFO] I'm sorting PRs based on \"creation date\" in the \"ascending\" direction"
+- started_at: "2025-11-02T23:31:11Z"
+  finished_at: "2025-11-02T23:31:47Z"
+  took_ms: 36000
+  mode: dry-run
+  config:
+    base_branch: main
+    head_pattern: (dependabot|update)
+    merge_if_blocked: false
+    merge_if_checks_skipped: true
+    merge_type: squash
+    sort_by: created
+    sort_direction: asc
+    flags:
+      show_repos_with_no_prs: false
+      show_prs_from_untrusted_authors: false
+      show_prs_with_unmatched_head: false
+      skip_disqualifications_in_summary: false
+  summary:
+    num_disqualifications: 1
+    num_errors: 2
+    num_merged: 0
+  repos:
+    - repo: dhth/mrj
+      owner: dhth
+      name: mrj
+      status: finished
+      prs:
+        - number: 12
+          title: "build: bump clap from 4.5.39 to 4.5.40"
+          url: "https://github.com/dhth/mrj/pull/12"
+          created_at: "2025-11-02T23:00:00Z"
+          updated_at: "2025-11-02T23:10:00Z"
+          status: disqualified
+          qualifications:
+            - kind: head
+              value: dependabot/cargo/clap-4.5.40
+          disqualification:
+            kind: author
+            value: untrusted-bot
+          merged: false
+        - number: 13
+          title: "build: bump tera from 1.19.0 to 1.20.1"
+          url: "https://github.com/dhth/mrj/pull/13"
+          created_at: "2025-11-02T23:05:00Z"
+          updated_at: "2025-11-02T23:12:00Z"
+          status: qualified
+          qualifications:
+            - kind: head
+              value: dependabot/cargo/tera-1.20.1
+            - kind: author
+              value: "dependabot[bot]"
+            - kind: check
+              name: test
+              conclusion: success
+          merged: false
+        - number: 14
+          title: "build: bump regex from 1.12.2 to 1.12.3"
+          url: "https://github.com/dhth/mrj/pull/14"
+          created_at: "2025-11-02T23:08:00Z"
+          updated_at: "2025-11-02T23:15:00Z"
+          status: errored
+          qualifications:
+            - kind: head
+              value: dependabot/cargo/regex-1.12.3
+          error: "couldn't merge PR: GitHub API was down"
+          merged: false
+    - repo: dhth/bmm
+      owner: dhth
+      name: bmm
+      status: errored
+      error: "couldn't fetch open PRs for repo: GitHub API returned a 404"
+      prs: []
+- started_at: "2025-11-01T22:32:41Z"
+  finished_at: "2025-11-01T22:33:11Z"
+  took_ms: 30000
+  mode: execute
+  config:
+    base_branch: main
+    head_pattern: dependabot
+    merge_if_blocked: false
+    merge_if_checks_skipped: false
+    merge_type: squash
+    sort_by: updated
+    sort_direction: desc
+    flags:
+      show_repos_with_no_prs: true
+      show_prs_from_untrusted_authors: false
+      show_prs_with_unmatched_head: false
+      skip_disqualifications_in_summary: false
+  summary:
+    num_disqualifications: 0
+    num_errors: 0
+    num_merged: 1
+  repos:
+    - repo: dhth/mrj
+      owner: dhth
+      name: mrj
+      status: finished
+      prs:
+        - number: 11
+          title: "build: bump octocrab from 0.49.6 to 0.49.7"
+          url: "https://github.com/dhth/mrj/pull/11"
+          created_at: "2025-11-01T22:20:00Z"
+          updated_at: "2025-11-01T22:28:00Z"
+          status: qualified
+          qualifications:
+            - kind: head
+              value: dependabot/cargo/octocrab-0.49.7
+            - kind: author
+              value: "dependabot[bot]"
+          merged: true

--- a/src/report/testdata/custom_template.html
+++ b/src/report/testdata/custom_template.html
@@ -1,12 +1,30 @@
-{{ title }}
-Generated at {{ timestamp }}
-{%- if runs | length > 0 %}
-{%- for run in runs %}
--> {{ run.label }}
----
-{{ run.contents }}
----
-{%- endfor %}
-{%- else %}
-No runs found yet.
-{%- endif %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <p>Generated at {{ timestamp }}</p>
+
+    {%- if runs | length > 0 %}
+    {%- for run in runs %}
+    <section>
+        <h2>{{ run.finished_at | date(format="%Y-%m-%d") }}</h2>
+        <p>mode={{ run.mode }} took={{ run.took_ms }}</p>
+        <p>
+            summary={{ run.summary.num_merged }} merged / {{ run.summary.num_disqualifications }} disqualified / {{ run.summary.num_errors }} errors
+        </p>
+        <ul>
+            {%- for repo in run.repos %}
+            <li>repo={{ repo.repo }} status={{ repo.status }} prs={{ repo.prs | length }}</li>
+            {%- endfor %}
+        </ul>
+    </section>
+    {%- endfor %}
+    {%- else %}
+    <p>No runs found yet.</p>
+    {%- endif %}
+</body>
+</html>

--- a/src/report/testdata/rundata/runs/run-576--sat-nov-01.json
+++ b/src/report/testdata/rundata/runs/run-576--sat-nov-01.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "run": {
+    "started_at": "2025-11-01T22:32:41Z",
+    "finished_at": "2025-11-01T22:33:11Z",
+    "took_ms": 30000,
+    "mode": "execute",
+    "config": {
+      "base_branch": "main",
+      "head_pattern": "dependabot",
+      "merge_if_blocked": false,
+      "merge_if_checks_skipped": false,
+      "merge_type": "squash",
+      "sort_by": "updated",
+      "sort_direction": "desc",
+      "flags": {
+        "show_repos_with_no_prs": true,
+        "show_prs_from_untrusted_authors": false,
+        "show_prs_with_unmatched_head": false,
+        "skip_disqualifications_in_summary": false
+      }
+    },
+    "summary": {
+      "num_disqualifications": 0,
+      "num_errors": 0,
+      "num_merged": 1
+    },
+    "repos": [
+      {
+        "repo": "dhth/mrj",
+        "owner": "dhth",
+        "name": "mrj",
+        "status": "finished",
+        "prs": [
+          {
+            "number": 11,
+            "title": "build: bump octocrab from 0.49.6 to 0.49.7",
+            "url": "https://github.com/dhth/mrj/pull/11",
+            "created_at": "2025-11-01T22:20:00Z",
+            "updated_at": "2025-11-01T22:28:00Z",
+            "status": "qualified",
+            "qualifications": [
+              { "kind": "head", "value": "dependabot/cargo/octocrab-0.49.7" },
+              { "kind": "author", "value": "dependabot[bot]" }
+            ],
+            "merged": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/report/testdata/rundata/runs/run-576--sat-nov-01.txt
+++ b/src/report/testdata/rundata/runs/run-576--sat-nov-01.txt
@@ -1,3 +1,0 @@
-[INFO] The time right now is 2025-11-01 22:33:11.521555796 UTC
-[INFO] I'm only looking for PRs where the base branch is "main"
-[INFO] I'm sorting PRs based on "creation date" in the "ascending" direction

--- a/src/report/testdata/rundata/runs/run-577--sun-nov-02.json
+++ b/src/report/testdata/rundata/runs/run-577--sun-nov-02.json
@@ -1,0 +1,87 @@
+{
+  "version": 1,
+  "run": {
+    "started_at": "2025-11-02T23:31:11Z",
+    "finished_at": "2025-11-02T23:31:47Z",
+    "took_ms": 36000,
+    "mode": "dry-run",
+    "config": {
+      "base_branch": "main",
+      "head_pattern": "(dependabot|update)",
+      "merge_if_blocked": false,
+      "merge_if_checks_skipped": true,
+      "merge_type": "squash",
+      "sort_by": "created",
+      "sort_direction": "asc",
+      "flags": {
+        "show_repos_with_no_prs": false,
+        "show_prs_from_untrusted_authors": false,
+        "show_prs_with_unmatched_head": false,
+        "skip_disqualifications_in_summary": false
+      }
+    },
+    "summary": {
+      "num_disqualifications": 1,
+      "num_errors": 2,
+      "num_merged": 0
+    },
+    "repos": [
+      {
+        "repo": "dhth/mrj",
+        "owner": "dhth",
+        "name": "mrj",
+        "status": "finished",
+        "prs": [
+          {
+            "number": 12,
+            "title": "build: bump clap from 4.5.39 to 4.5.40",
+            "url": "https://github.com/dhth/mrj/pull/12",
+            "created_at": "2025-11-02T23:00:00Z",
+            "updated_at": "2025-11-02T23:10:00Z",
+            "status": "disqualified",
+            "qualifications": [
+              { "kind": "head", "value": "dependabot/cargo/clap-4.5.40" }
+            ],
+            "disqualification": { "kind": "author", "value": "untrusted-bot" },
+            "merged": false
+          },
+          {
+            "number": 13,
+            "title": "build: bump tera from 1.19.0 to 1.20.1",
+            "url": "https://github.com/dhth/mrj/pull/13",
+            "created_at": "2025-11-02T23:05:00Z",
+            "updated_at": "2025-11-02T23:12:00Z",
+            "status": "qualified",
+            "qualifications": [
+              { "kind": "head", "value": "dependabot/cargo/tera-1.20.1" },
+              { "kind": "author", "value": "dependabot[bot]" },
+              { "kind": "check", "name": "test", "conclusion": "success" }
+            ],
+            "merged": false
+          },
+          {
+            "number": 14,
+            "title": "build: bump regex from 1.12.2 to 1.12.3",
+            "url": "https://github.com/dhth/mrj/pull/14",
+            "created_at": "2025-11-02T23:08:00Z",
+            "updated_at": "2025-11-02T23:15:00Z",
+            "status": "errored",
+            "qualifications": [
+              { "kind": "head", "value": "dependabot/cargo/regex-1.12.3" }
+            ],
+            "error": "couldn't merge PR: GitHub API was down",
+            "merged": false
+          }
+        ]
+      },
+      {
+        "repo": "dhth/bmm",
+        "owner": "dhth",
+        "name": "bmm",
+        "status": "errored",
+        "error": "couldn't fetch open PRs for repo: GitHub API returned a 404",
+        "prs": []
+      }
+    ]
+  }
+}

--- a/src/report/testdata/rundata/runs/run-577--sun-nov-02.txt
+++ b/src/report/testdata/rundata/runs/run-577--sun-nov-02.txt
@@ -1,3 +1,0 @@
-[INFO] The time right now is 2025-11-01 23:31:47.722303883 UTC
-[INFO] I'm only looking for PRs where the base branch is "main"
-[INFO] I'm sorting PRs based on "creation date" in the "ascending" direction

--- a/tests/report_test.rs
+++ b/tests/report_test.rs
@@ -22,7 +22,7 @@ fn debug_mode_works() {
     DEBUG INFO
 
     command:        Generate report
-    output file:    output.txt
+    output file:    output.json
     open report:    false
     num runs:       10
     title:          mrj runs

--- a/tests/run_test.rs
+++ b/tests/run_test.rs
@@ -30,7 +30,7 @@ fn debug_mode_works() {
     config file:                          tests/assets/valid-config-with-all-props.toml
     repos (overridden):                   []
     output to file:                       false
-    output file:                          output.txt
+    output file:                          output.json
     write summary:                        false
     summary file:                         summary.txt
     skip disqualifications in summary:    false
@@ -69,7 +69,7 @@ fn overriding_repos_works() {
     config file:                          tests/assets/valid-config-with-no-repos.toml
     repos (overridden):                   ["dhth/mrj", "dhth/bmm"]
     output to file:                       false
-    output file:                          output.txt
+    output file:                          output.json
     write summary:                        false
     summary file:                         summary.txt
     skip disqualifications in summary:    false


### PR DESCRIPTION
Replace the old text-based run artifact with a structured JSON
persistence format and move report generation to read from that stored
run data.

This refactor separates the run pipeline into clearer stages: repo/PR
processing, stdout logging, run summarization, persistence, and report
rendering. The merge flow now produces a filtered result set first, then
uses that same result for both user-facing output and persisted history
so the stored artifact stays aligned with what the user saw during the
run.

The report pipeline now consumes structured run snapshots instead of raw
text files. That makes the HTML report depend on explicit run, repo, and
PR records rather than parsing terminal-oriented output, and it allows
the built-in report template to present recent runs as a more
structured, action-oriented view.

The change also introduces an explicit persistence schema and versioned
run envelope to give the stored format a stable shape for future
evolution.
