### PR TITLE
allow merging on neutral check conclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Allow merging PRs with neutral check conclusions via an optional configuration parameter
+
 ## [v0.5.0] - May 29, 2026
 
 ### Changed

--- a/src/assets/sample-config.toml
+++ b/src/assets/sample-config.toml
@@ -34,7 +34,7 @@ merge_if_blocked = true
 merge_if_checks_skipped = true
 
 # by default mrj will not merge PRs where one or more checks have concluded with a neutral status
-# if this setting is ON, mrj will consider neutral checks successful enough to merge
+# if this setting is ON, mrj will consider neutral check conclusions acceptable for merging
 # (optional, default: false)
 merge_if_checks_neutral = false
 

--- a/src/assets/sample-config.toml
+++ b/src/assets/sample-config.toml
@@ -33,6 +33,11 @@ merge_if_blocked = true
 # (optional, default: true)
 merge_if_checks_skipped = true
 
+# by default mrj will not merge PRs where one or more checks have concluded with a neutral status
+# if this setting is ON, mrj will consider neutral checks successful enough to merge
+# (optional, default: false)
+merge_if_checks_neutral = false
+
 # how to merge the pull request
 # can be one of: [squash, merge, rebase]
 # make sure the choice is actually enabled in your settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub merge_if_blocked: bool,
     #[serde(default = "default_true")]
     pub merge_if_checks_skipped: bool,
+    #[serde(default = "default_false")]
+    pub merge_if_checks_neutral: bool,
     pub merge_type: MergeType,
     #[serde(default = "default_sort")]
     pub sort_by: SortBy,
@@ -79,6 +81,7 @@ base_branch = "main"
 head_pattern = "(dependabot|update)"
 merge_if_blocked = true
 merge_if_checks_skipped = true
+merge_if_checks_neutral = true
 merge_type = "squash"
 sort_by = "updated"
 sort_direction = "desc"
@@ -101,6 +104,7 @@ sort_direction = "desc"
         base_branch: main
         merge_if_blocked: true
         merge_if_checks_skipped: true
+        merge_if_checks_neutral: true
         merge_type: Squash
         sort_by: updated
         sort_direction: desc
@@ -137,6 +141,7 @@ merge_type = "squash"
         base_branch: ~
         merge_if_blocked: false
         merge_if_checks_skipped: true
+        merge_if_checks_neutral: false
         merge_type: Squash
         sort_by: created
         sort_direction: asc

--- a/src/merge/log.rs
+++ b/src/merge/log.rs
@@ -187,6 +187,10 @@ Disqualifications
             self.info("I won't merge PRs if checks are skipped");
         }
 
+        if config.merge_if_checks_neutral {
+            self.info("I will merge PRs if checks conclude with a neutral status");
+        }
+
         if self.behaviours.show_repos_with_no_prs {
             self.info("I will show repositories that have no PRs");
         }

--- a/src/merge/process.rs
+++ b/src/merge/process.rs
@@ -198,6 +198,12 @@ async fn merge_pr(
                     ));
                 }
             }
+            Some("neutral") if config.merge_if_checks_neutral => {
+                pr_check.add_qualification(Q::Check {
+                    name: check.name.clone(),
+                    conclusion: "neutral".to_string(),
+                });
+            }
             Some(non_successful_conclusion) => {
                 return MergeAttemptOutcome::Final(MergeResult::Disqualified(pr_check.disqualify(
                     DQ::Check {

--- a/src/persistence/io.rs
+++ b/src/persistence/io.rs
@@ -75,6 +75,7 @@ fn map_config(config: &Config, behaviours: &RunBehaviours) -> StoredRunConfig {
             .map(|pattern| pattern.re.as_str().to_string()),
         merge_if_blocked: config.merge_if_blocked,
         merge_if_checks_skipped: config.merge_if_checks_skipped,
+        merge_if_checks_neutral: config.merge_if_checks_neutral,
         merge_type: (&config.merge_type).into(),
         sort_by: (&config.sort_by).into(),
         sort_direction: (&config.sort_direction).into(),

--- a/src/persistence/schema.rs
+++ b/src/persistence/schema.rs
@@ -41,6 +41,8 @@ pub struct StoredRunConfig {
     pub head_pattern: Option<String>,
     pub merge_if_blocked: bool,
     pub merge_if_checks_skipped: bool,
+    #[serde(default)]
+    pub merge_if_checks_neutral: bool,
     pub merge_type: StoredMergeType,
     pub sort_by: StoredSortBy,
     pub sort_direction: StoredSortDirection,
@@ -178,4 +180,32 @@ pub enum StoredDisqualification {
     State {
         value: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_run_config_defaults_missing_merge_if_checks_neutral_to_false() -> anyhow::Result<()> {
+        let config: StoredRunConfig = serde_json::from_str(
+            r#"{
+                "merge_if_blocked": false,
+                "merge_if_checks_skipped": true,
+                "merge_type": "squash",
+                "sort_by": "created",
+                "sort_direction": "asc",
+                "flags": {
+                    "show_repos_with_no_prs": false,
+                    "show_prs_from_untrusted_authors": false,
+                    "show_prs_with_unmatched_head": false,
+                    "skip_disqualifications_in_summary": false
+                }
+            }"#,
+        )?;
+
+        assert!(!config.merge_if_checks_neutral);
+
+        Ok(())
+    }
 }

--- a/src/report/assets/templates/index.html
+++ b/src/report/assets/templates/index.html
@@ -412,6 +412,7 @@
                     &middot; sort={{ run.config.sort_by }}/{{ run.config.sort_direction }}
                     &middot; merge-if-blocked={{ run.config.merge_if_blocked }}
                     &middot; merge-if-checks-skipped={{ run.config.merge_if_checks_skipped }}
+                    &middot; merge-if-checks-neutral={{ run.config.merge_if_checks_neutral }}
                 </div>
 
                 <div class="board-table-wrap">
@@ -439,7 +440,7 @@
                                 <td class="cell-repo">{{ repo.repo }}</td>
                                 <td class="cell-num">{{ pr.number }}</td>
                                 <td class="cell-wrap"><a href="{{ pr.url }}" target="_blank" rel="noopener noreferrer">{{ pr.title }}</a></td>
-                                <td class="cell-wrap remarks remarks-ok"></td>
+                                <td class="cell-wrap remarks remarks-ok">{%- for qualification in pr.qualifications %}{% if qualification.kind == "check" and qualification.conclusion == "neutral" %}<div>&#x2713; check &middot; {{ qualification.name }}: {{ qualification.conclusion }}</div>{% endif %}{%- endfor %}</td>
                             </tr>
                             {%- endif %}
                             {%- endfor %}

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -116,6 +116,7 @@ mod tests {
                     head_pattern: Some("(dependabot|update)".into()),
                     merge_if_blocked: false,
                     merge_if_checks_skipped: true,
+                    merge_if_checks_neutral: false,
                     merge_type: StoredMergeType::Squash,
                     sort_by: StoredSortBy::Created,
                     sort_direction: StoredSortDirection::Asc,
@@ -244,6 +245,7 @@ mod tests {
                     head_pattern: Some("dependabot".into()),
                     merge_if_blocked: false,
                     merge_if_checks_skipped: false,
+                    merge_if_checks_neutral: true,
                     merge_type: StoredMergeType::Squash,
                     sort_by: StoredSortBy::Updated,
                     sort_direction: StoredSortDirection::Desc,
@@ -286,6 +288,10 @@ mod tests {
                             },
                             StoredQualification::Author {
                                 value: "dependabot[bot]".into(),
+                            },
+                            StoredQualification::Check {
+                                name: "advisory".into(),
+                                conclusion: "neutral".into(),
                             },
                         ],
                         disqualification: None,

--- a/src/report/snapshots/mrj__report__html__tests__render_report_works_for_builtin_template.snap
+++ b/src/report/snapshots/mrj__report__html__tests__render_report_works_for_builtin_template.snap
@@ -409,6 +409,7 @@ expression: result
                     &middot; sort=created/asc
                     &middot; merge-if-blocked=false
                     &middot; merge-if-checks-skipped=true
+                    &middot; merge-if-checks-neutral=false
                 </div>
 
                 <div class="board-table-wrap">
@@ -472,6 +473,7 @@ expression: result
                     &middot; sort=updated/desc
                     &middot; merge-if-blocked=false
                     &middot; merge-if-checks-skipped=false
+                    &middot; merge-if-checks-neutral=true
                 </div>
 
                 <div class="board-table-wrap">
@@ -491,7 +493,7 @@ expression: result
                                 <td class="cell-repo">dhth&#x2F;mrj</td>
                                 <td class="cell-num">11</td>
                                 <td class="cell-wrap"><a href="https:&#x2F;&#x2F;github.com&#x2F;dhth&#x2F;mrj&#x2F;pull&#x2F;11" target="_blank" rel="noopener noreferrer">build: bump octocrab from 0.49.6 to 0.49.7</a></td>
-                                <td class="cell-wrap remarks remarks-ok"></td>
+                                <td class="cell-wrap remarks remarks-ok"><div>&#x2713; check &middot; advisory: neutral</div></td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/report/snapshots/mrj__report__io__tests__gather_run_data_works_correctly.snap
+++ b/src/report/snapshots/mrj__report__io__tests__gather_run_data_works_correctly.snap
@@ -11,6 +11,7 @@ expression: result
     head_pattern: (dependabot|update)
     merge_if_blocked: false
     merge_if_checks_skipped: true
+    merge_if_checks_neutral: false
     merge_type: squash
     sort_by: created
     sort_direction: asc
@@ -83,6 +84,7 @@ expression: result
     head_pattern: dependabot
     merge_if_blocked: false
     merge_if_checks_skipped: false
+    merge_if_checks_neutral: false
     merge_type: squash
     sort_by: updated
     sort_direction: desc

--- a/tests/assets/valid-config-with-all-props.toml
+++ b/tests/assets/valid-config-with-all-props.toml
@@ -12,5 +12,6 @@ base_branch = "main"
 head_pattern = "(dependabot|update)"
 merge_if_blocked = true
 merge_if_checks_skipped = true
+merge_if_checks_neutral = true
 merge_type = "squash"
 sort_by = "created"

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -123,6 +123,11 @@ fn printing_sample_config_works() {
     # (optional, default: true)
     merge_if_checks_skipped = true
 
+    # by default mrj will not merge PRs where one or more checks have concluded with a neutral status
+    # if this setting is ON, mrj will consider neutral checks successful enough to merge
+    # (optional, default: false)
+    merge_if_checks_neutral = false
+
     # how to merge the pull request
     # can be one of: [squash, merge, rebase]
     # make sure the choice is actually enabled in your settings

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -124,7 +124,7 @@ fn printing_sample_config_works() {
     merge_if_checks_skipped = true
 
     # by default mrj will not merge PRs where one or more checks have concluded with a neutral status
-    # if this setting is ON, mrj will consider neutral checks successful enough to merge
+    # if this setting is ON, mrj will consider neutral check conclusions acceptable for merging
     # (optional, default: false)
     merge_if_checks_neutral = false
 


### PR DESCRIPTION
Neutral check conclusions remain blocking by default, preserving the
conservative behavior expected from automated merging. Users can opt in
to treating them as non-blocking through configuration.

Persist the setting with backward-compatible defaults for existing run
history, while preserving the literal neutral conclusion in output and
reports.

Fixes https://github.com/dhth/mrj/issues/119.
